### PR TITLE
Fixed search problems on both plugins

### DIFF
--- a/plugin.video.amazon-test/default.py
+++ b/plugin.video.amazon-test/default.py
@@ -287,7 +287,6 @@ def Search():
     if searchString:
         url = 'searchString=%s%s' % (urllib.quote_plus(searchString), OfferGroup)
         listContent('Search', url, 1, 'search')
-    xbmc.executebuiltin('Action(Close)')
 
 
 def swapDB():

--- a/plugin.video.amazon/resources/lib/appfeed.py
+++ b/plugin.video.amazon/resources/lib/appfeed.py
@@ -111,7 +111,6 @@ def SEARCH_DB(searchString=None):
                 if not listtv.LIST_TVSHOWS('seriestitle', searchString, search=True):
                     addText(getString(30202))
                 SetView('tvshows', 'showview')
-        xbmc.executebuiltin('Action(Close)')
 
 
 def ExportList():


### PR DESCRIPTION
On an Android box with Kodi 16, both plugins would immediately jump back to the main menu after displaying search results. This commit removes the close actions at the end of the search function.

Fixes #16.