### PR TITLE
Replaced the python version checks

### DIFF
--- a/plugin.video.amazon-test/default.py
+++ b/plugin.video.amazon-test/default.py
@@ -245,19 +245,29 @@ def getURL(url, useCookie=False, silent=False, headers=None, rjson=True, attempt
         headers['Accept-Language'] = userAcceptLanguages
 
     try:
-        if sys.version_info[0:3] < (2, 7, 9):
-            Log('Using outdated Python version %d.%d.%d' % (sys.version_info[0:3]))
-            Dialog.ok('Python outdated', 'Your Python version (%d.%d.%d) is outdated. You need at least version 2.7.9 to use this Addon.' % (sys.version_info[0:3]),
-                      'If you\'re on Linux please follow this guide to update Python:', 'https://goo.gl/CKtygz')
-            exit()
         r = session.get(url, headers=headers, cookies=cj, verify=verifySsl)
         response = r.text if not check else 'OK'
     except (requests.exceptions.Timeout,
             requests.exceptions.ConnectionError,
             requests.exceptions.SSLError,
-            requests.exceptions.HTTPError), e:
-        Log('Error reason: %s' % e, xbmc.LOGERROR)
-        if '429' or 'timed out' in e:
+            requests.exceptions.HTTPError,
+            requests.packages.urllib3.exceptions.SNIMissingWarning,
+            requests.packages.urllib3.exceptions.InsecurePlatformWarning), e:
+        eType = e.__class__.__name__
+        Log('Error reason: %s (%s)' % (e, eType), xbmc.LOGERROR)
+        if ('SNIMissingWarning' is eType):
+            Log('Using a Python/OpenSSL version which doesn\'t support SNI for TLS connections.', xbmc.LOGERROR)
+            Dialog.ok('No SNI for TLS', 'Your current Python/OpenSSL environment does not support SNI over TLS connections.',
+                    'You can find a Linux guide on how to update Python and its modules for Kodi here:', 'https://goo.gl/CKtygz',
+                    'Additionally, follow this guide to update the required modules:', 'https://goo.gl/ksbbU2')
+            exit()
+        if ('InsecurePlatformWarning' is eType):
+            Log('Using an outdated SSL module.', xbmc.LOGERROR)
+            Dialog.ok('SSL module outdated', 'The SSL module for Python is outdated.',
+                    'You can find a Linux guide on how to update Python and its modules for Kodi here:', 'https://goo.gl/CKtygz',
+                    'Additionally, follow this guide to update the required modules:', 'https://goo.gl/ksbbU2')
+            exit()
+        if ('429' in e) or ('Timeout' is eType):
             attempt += 1 if not check else 10
             logout = 'Attempt #%s' % attempt
             if '429' in e:

--- a/plugin.video.amazon-test/default.py
+++ b/plugin.video.amazon-test/default.py
@@ -24,6 +24,7 @@ import threading
 import urllib
 import urlparse
 import uuid
+import warnings
 
 from pyDes import *
 import mechanize
@@ -184,6 +185,8 @@ TV_SHOWS_PATH = os.path.join(EXPORT_PATH, 'TV')
 ms_mov = ms_mov if ms_mov else 'Amazon Movies'
 ms_tv = ms_tv if ms_tv else 'Amazon TV'
 
+warnings.simplefilter('error', requests.packages.urllib3.exceptions.SNIMissingWarning)
+warnings.simplefilter('error', requests.packages.urllib3.exceptions.InsecurePlatformWarning)
 
 def setView(content, updateListing=False):
     if content == 'movie':
@@ -255,19 +258,19 @@ def getURL(url, useCookie=False, silent=False, headers=None, rjson=True, attempt
             requests.packages.urllib3.exceptions.InsecurePlatformWarning), e:
         eType = e.__class__.__name__
         Log('Error reason: %s (%s)' % (e, eType), xbmc.LOGERROR)
-        if ('SNIMissingWarning' is eType):
+        if 'SNIMissingWarning' in eType:
             Log('Using a Python/OpenSSL version which doesn\'t support SNI for TLS connections.', xbmc.LOGERROR)
             Dialog.ok('No SNI for TLS', 'Your current Python/OpenSSL environment does not support SNI over TLS connections.',
-                    'You can find a Linux guide on how to update Python and its modules for Kodi here:', 'https://goo.gl/CKtygz',
-                    'Additionally, follow this guide to update the required modules:', 'https://goo.gl/ksbbU2')
+                      'You can find a Linux guide on how to update Python and its modules for Kodi here: https://goo.gl/CKtygz',
+                      'Additionally, follow this guide to update the required modules: https://goo.gl/ksbbU2')
             exit()
-        if ('InsecurePlatformWarning' is eType):
+        if 'InsecurePlatformWarning' in eType:
             Log('Using an outdated SSL module.', xbmc.LOGERROR)
-            Dialog.ok('SSL module outdated', 'The SSL module for Python is outdated.',
-                    'You can find a Linux guide on how to update Python and its modules for Kodi here:', 'https://goo.gl/CKtygz',
-                    'Additionally, follow this guide to update the required modules:', 'https://goo.gl/ksbbU2')
+            Dialog.ok('SSL module outdated', 'The SSL module for Python is outdated.', 
+                      'You can find a Linux guide on how to update Python and its modules for Kodi here: https://goo.gl/CKtygz', 
+                      'Additionally, follow this guide to update the required modules: https://goo.gl/ksbbU2')
             exit()
-        if ('429' in e) or ('Timeout' is eType):
+        if ('429' in e) or ('Timeout' in eType):
             attempt += 1 if not check else 10
             logout = 'Attempt #%s' % attempt
             if '429' in e:

--- a/plugin.video.amazon/resources/lib/common.py
+++ b/plugin.video.amazon/resources/lib/common.py
@@ -26,6 +26,7 @@ import socket
 import time
 import requests
 import pickle
+import warnings
 
 addon = xbmcaddon.Addon()
 pluginname = addon.getAddonInfo('name')
@@ -56,6 +57,9 @@ socket.setdefaulttimeout(30)
 is_addon = 'inputstream.adaptive'
 regex_ovf = "((?i)(\[|\()(omu|ov).*(\)|\]))|\sOmU"
 sessions = {}
+
+warnings.simplefilter('error', requests.packages.urllib3.exceptions.SNIMissingWarning)
+warnings.simplefilter('error', requests.packages.urllib3.exceptions.InsecurePlatformWarning)
 
 try:
     pluginhandle = int(sys.argv[1])
@@ -229,19 +233,19 @@ def getURL(url, useCookie=False, silent=False, headers=None, rjson=True, attempt
             requests.packages.urllib3.exceptions.InsecurePlatformWarning), e:
         eType = e.__class__.__name__
         Log('Error reason: %s (%s)' % (e, eType), xbmc.LOGERROR)
-        if ('SNIMissingWarning' is eType):
+        if 'SNIMissingWarning' in eType:
             Log('Using a Python/OpenSSL version which doesn\'t support SNI for TLS connections.', xbmc.LOGERROR)
             Dialog.ok('No SNI for TLS', 'Your current Python/OpenSSL environment does not support SNI over TLS connections.',
-                    'You can find a Linux guide on how to update Python and its modules for Kodi here:', 'https://goo.gl/CKtygz',
-                    'Additionally, follow this guide to update the required modules:', 'https://goo.gl/ksbbU2')
+                      'You can find a Linux guide on how to update Python and its modules for Kodi here: https://goo.gl/CKtygz',
+                      'Additionally, follow this guide to update the required modules: https://goo.gl/ksbbU2')
             exit()
-        if ('InsecurePlatformWarning' is eType):
+        if 'InsecurePlatformWarning' in eType:
             Log('Using an outdated SSL module.', xbmc.LOGERROR)
-            Dialog.ok('SSL module outdated', 'The SSL module for Python is outdated.',
-                    'You can find a Linux guide on how to update Python and its modules for Kodi here:', 'https://goo.gl/CKtygz',
-                    'Additionally, follow this guide to update the required modules:', 'https://goo.gl/ksbbU2')
+            Dialog.ok('SSL module outdated', 'The SSL module for Python is outdated.', 
+                      'You can find a Linux guide on how to update Python and its modules for Kodi here: https://goo.gl/CKtygz', 
+                      'Additionally, follow this guide to update the required modules: https://goo.gl/ksbbU2')
             exit()
-        if ('429' in e) or ('Timeout' is eType):
+        if ('429' in e) or ('Timeout' in eType):
             attempt += 1 if not check else 10
             logout = 'Attempt #%s' % attempt
             if '429' in e:

--- a/plugin.video.amazon/resources/lib/common.py
+++ b/plugin.video.amazon/resources/lib/common.py
@@ -219,19 +219,29 @@ def getURL(url, useCookie=False, silent=False, headers=None, rjson=True, attempt
         headers['Accept-Language'] = 'de-de, en-gb;q=0.2, en;q=0.1'
 
     try:
-        if sys.version_info[0:3] < (2, 7, 9):
-            Log('Using outdated Python version %d.%d.%d' % (sys.version_info[0:3]))
-            Dialog.ok('Python outdated', 'Your Python version (%d.%d.%d) is outdated. You need at least version 2.7.9 to use this Addon.' % (sys.version_info[0:3]),
-                      'If you\'re on Linux please follow this guide to update Python:', 'https://goo.gl/CKtygz')
-            exit()
         r = session.get(url, headers=headers, cookies=cj, verify=verifySsl)
         response = r.text if not check else 'OK'
     except (requests.exceptions.Timeout,
             requests.exceptions.ConnectionError,
             requests.exceptions.SSLError,
-            requests.exceptions.HTTPError), e:
-        Log('Error reason: %s' % e, xbmc.LOGERROR)
-        if '429' or 'timed out' in e:
+            requests.exceptions.HTTPError,
+            requests.packages.urllib3.exceptions.SNIMissingWarning,
+            requests.packages.urllib3.exceptions.InsecurePlatformWarning), e:
+        eType = e.__class__.__name__
+        Log('Error reason: %s (%s)' % (e, eType), xbmc.LOGERROR)
+        if ('SNIMissingWarning' is eType):
+            Log('Using a Python/OpenSSL version which doesn\'t support SNI for TLS connections.', xbmc.LOGERROR)
+            Dialog.ok('No SNI for TLS', 'Your current Python/OpenSSL environment does not support SNI over TLS connections.',
+                    'You can find a Linux guide on how to update Python and its modules for Kodi here:', 'https://goo.gl/CKtygz',
+                    'Additionally, follow this guide to update the required modules:', 'https://goo.gl/ksbbU2')
+            exit()
+        if ('InsecurePlatformWarning' is eType):
+            Log('Using an outdated SSL module.', xbmc.LOGERROR)
+            Dialog.ok('SSL module outdated', 'The SSL module for Python is outdated.',
+                    'You can find a Linux guide on how to update Python and its modules for Kodi here:', 'https://goo.gl/CKtygz',
+                    'Additionally, follow this guide to update the required modules:', 'https://goo.gl/ksbbU2')
+            exit()
+        if ('429' in e) or ('Timeout' is eType):
             attempt += 1 if not check else 10
             logout = 'Attempt #%s' % attempt
             if '429' in e:


### PR DESCRIPTION
As reported in #88 the python version checks in 39b12597e5845e3b1dfe1f85d9bdfe92900ca603 introduced a bug where previously working environments stopped completely. I changed the raw python version check and targeted the problems with exception handling.

This should solve both problems once and for all.