### PR TITLE
Added support for forced subtitles

### DIFF
--- a/plugin.video.amazon-test/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.amazon-test/resources/language/resource.language.en_gb/strings.po
@@ -133,7 +133,11 @@ msgctxt "#30026"
 msgid "Kodi setting otherwise all"
 msgstr ""
 
-#empty strings from id 30027 to 30029
+msgctxt "#30027"
+msgid "Kodi setting otherwise only forced"
+msgstr ""
+
+#empty strings from id 30028 to 30029
 
 msgctxt "#30029"
 msgid "Movie View"

--- a/plugin.video.amazon-test/resources/settings.xml
+++ b/plugin.video.amazon-test/resources/settings.xml
@@ -18,7 +18,7 @@
         <setting id="pin" type="number" label="30046" enable="eq(-1,true)" default="" visible="lt(-14,2)" />
         <setting id="waitprepin" type="labelenum" values="1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30" label="30057" default="10" visible="eq(-4,false) + lt(-15,2)" enable="eq(-2,true) + eq(-4,false)"/>
         <setting id="waitpin" type="labelenum" values="1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30" enable="eq(-3,true) + eq(-5,true)" label="30047" default="5" visible="eq(-5,true) + lt(-16,2)"/>
-        <setting id="sub_lang" type="enum" label="30005" visible="eq(-17,3)" default="0" lvalues='30023|30024|30025|30026'/>
+        <setting id="sub_lang" type="enum" label="30005" visible="eq(-17,3)" default="0" lvalues='30023|30024|30025|30026|30027'/>
         <setting id="pref_host" type="labelenum" label="30019" visible="eq(-18,3)" values="Auto|Akamai|Cloudfront|Level3|Limelight" default="Auto"/>
         <setting id="is_settings" type="action" label="30013" visible="eq(-19,3)" action="RunPlugin(plugin://plugin.video.amazon-test/?mode=openSettings&url=is)" option="close"/>
         <setting id="age_settings" type="action" label="30018" visible="eq(-20,3)" action="RunPlugin(plugin://plugin.video.amazon-test/?mode=ageSettings)" option="close"/>


### PR DESCRIPTION
Forced subs (`ForcedNarratives` for PrimeVideo) are not shown in PrimeVideo player's subs selection menu, but they are selected by default with the corresponding audio track, e.g.:

![screenshot_20180328_185602](https://user-images.githubusercontent.com/33163433/38044408-f64708ac-32b9-11e8-923f-c84e89abeffb.png)

They are retrieved alongside normal subs by getting `GetPlaybackResources` with `ForcedNarratives` as desired resource, and the result is stored in `forcedNarratives` list which has the same format of `subtitlesUrls` list (every element has `languageCode`, `displayName`, `url`, etc., keys).
They can be recognized by the word _"forced"_ in `displayName` key (just like [CC] subs).

To parse them properly I've appended `data['forcedNarratives']` list to `data['subtitlesUrls']` list for the subs parsing loop and I've added the suffix ".forced" to the matching subtitles' language code which is also appended to the subtitles' temp filename so Kodi can recognize them as forced subs ([wiki](https://kodi.wiki/view/subtitles#Using_Forced_Subtitles)).

![screenshot_20180328_194358](https://user-images.githubusercontent.com/33163433/38046712-aacfda5a-32c0-11e8-84a8-220823e72671.png)
![screenshot_20180328_194438](https://user-images.githubusercontent.com/33163433/38046713-aaf86ba0-32c0-11e8-9643-7976b73febb0.png)

The only problem is that when you change audio track, Kodi automatically switches the forced subs language to match the audio lang, but it keeps displaying the old ones. You have to manually reselect the correct forced subs to display them. But I guess this is a Kodi bug.
___
I've also added an option to only download forced subtitles as fallback subs if Kodi's preferred subs lang is not set, and by doing that I've also tried to improve how fallback subs are chosen (this way an option for the preferred fallback language could be added to let the user choose it, removing the hardcoded `'en'` fallback lang).