### PR TITLE
Add user notification on territorial error

### DIFF
--- a/plugin.video.amazon-test/default.py
+++ b/plugin.video.amazon-test/default.py
@@ -2312,6 +2312,9 @@ def LogIn(ask=True):
 
     if not user['baseurl']:
         user = getTerritory(user)
+        if False is user[1]:
+            return False
+        user = user[0]
 
     if ask:
         keyboard = xbmc.Keyboard(email, getString(30002))
@@ -2447,6 +2450,9 @@ def loadUser(key='', empty=False):
         user = user[0]
         if key and key not in user.keys():
             user = getTerritory(user)
+            if False is user[1]:
+                Dialog.notification(__plugin__, getString(30219), xbmcgui.NOTIFICATION_ERROR)
+            user = user[0]
             addUser(user)
         return user.get(key, user)
     else:
@@ -2514,6 +2520,8 @@ def getTerritory(user):
 
     data = getURL('https://na.api.amazonvideo.com/cdp/usage/v2/GetAppStartupConfig?deviceTypeID=A28RQHJKHM2A2W&deviceID=%s&firmware=1&version=1&format=json'
                   % deviceID)
+    if not hasattr(data, 'keys'):
+        return (user, False)
     if 'customerConfig' in data.keys():
         host = data['territoryConfig']['defaultVideoWebsite']
         reg = data['customerConfig']['homeRegion'].lower()
@@ -2522,7 +2530,7 @@ def getTerritory(user):
         user['baseurl'] = data['territoryConfig']['primeSignupBaseUrl']
         user['mid'] = data['territoryConfig']['avMarketplace']
         user['pv'] = 'primevideo' in host
-    return user
+    return (user, True)
 
 
 def MFACheck(br, email, soup):

--- a/plugin.video.amazon-test/resources/language/resource.language.de_de/strings.po
+++ b/plugin.video.amazon-test/resources/language/resource.language.de_de/strings.po
@@ -576,3 +576,7 @@ msgstr "Kein Stream-Hoster verfügbar"
 msgctxt "#30218"
 msgid "Due changes at Amazon's DRM encryption, it's not possible to use Inputstream for this video.\nPlease configure the fallback option in Settings, to use another Playback method."
 msgstr "Wegen Änderung von Amazons DRM-Verschlüsselung, ist es nicht möglich dieses Video mittels Inputstream wiederzugeben.\nBitte eine alternative Wiedergabemethode in den Einstellungen unter Fallback konfigurieren."
+
+msgctxt "#30219"
+msgid "Unable to retrieve Amazon's territorial configuration."
+msgstr ""

--- a/plugin.video.amazon-test/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.amazon-test/resources/language/resource.language.en_gb/strings.po
@@ -647,7 +647,11 @@ msgctxt "#30218"
 msgid "Due changes at Amazon's DRM encryption, it's not possible to use Inputstream for this video.\nPlease configure the fallback option in Settings, to use another Playback method."
 msgstr ""
 
-#empty strings from id 30218 to 30249
+msgctxt "#30219"
+msgid "Unable to retrieve Amazon's territorial configuration."
+msgstr ""
+
+#empty strings from id 30220 to 30249
 
 msgctxt "#30251"
 msgid "Connection error"


### PR DESCRIPTION
Adds the enhancement needed from #105, where the user has no visual feedback of things going wrong during the request of territorial informations. The causes of @oomek's problems are still unknown.