### PR TITLE
Forced subtitles support and .SRT download instead of .DFXP

### DIFF
--- a/plugin.video.amazon-test/default.py
+++ b/plugin.video.amazon-test/default.py
@@ -402,7 +402,9 @@ def PrimeVideo_BuildRoot():
         item = re.search('<a href="([^"]+)"[^>]*>\s*(.*?)\s*</a>', item)
         if None is not re.match('/storefront/home/', item.group(1)):
             continue
-        pvCatalog['root'][item.group(2)] = {'title': item.group(2), 'lazyLoadURL': BaseUrl + item.group(1) + '?_encoding=UTF8&format=json'}
+        # Remove react comments
+        title = re.sub('^<!--\s*[^>]+\s*-->', '', re.sub('<!--\s*[^>]+\s*-->$', '', item.group(2)))
+        pvCatalog['root'][title] = {'title': title, 'lazyLoadURL': BaseUrl + item.group(1) + '?_encoding=UTF8&format=json'}
     if 0 == len(pvCatalog['root']):
         Dialog.notification('PrimeVideo error', 'Unable to build the root catalog from primevideo.com', xbmcgui.NOTIFICATION_ERROR)
         Log('Unable to build the root catalog from primevideo.com', xbmc.LOGERROR)
@@ -2109,7 +2111,11 @@ def parseSubs(data):
         'sv-se':'sv',
     } # Clean up language and locale information where needed
     subs = []
+<<<<<<< Updated upstream
     if not down_lang or ('subtitleUrls' not in data and 'forcedNarratives' not in data):
+=======
+    if (not down_lang) or (('subtitleUrls' not in data) and ('forcedNarratives' not in data)):
+>>>>>>> Stashed changes
         return subs
 
     def_subs = []

--- a/plugin.video.amazon-test/default.py
+++ b/plugin.video.amazon-test/default.py
@@ -2089,15 +2089,11 @@ def parseSubs(data):
     down_lang = int('0' + addon.getSetting('sub_lang'))
     kodi_lang = jsonRPC('Settings.GetSettingValue', param={'setting': 'locale.subtitlelanguage'})
     kodi_lang = xbmc.convertLanguage(kodi_lang['value'], xbmc.ISO_639_1)
+    kodi_lang = kodi_lang if kodi_lang else xbmc.getLanguage(xbmc.ISO_639_1, False)
+    kodi_lang = kodi_lang if kodi_lang else 'en'
 
-    if down_lang < 2:
-        sub_lang = ''
-    elif down_lang == 2:
-        sub_lang = kodi_lang if kodi_lang else 'en'
-    elif down_lang == 3:
-        sub_lang = kodi_lang if kodi_lang else ''
-    elif down_lang == 4:
-        sub_lang = kodi_lang if kodi_lang else 'forced'
+    kodi_lang = '' if down_lang < 2 else kodi_lang
+    en_lang = '' if down_lang == 3 else 'en '
 
     localeConversion = {
         'ar-001':'ar',
@@ -2115,6 +2111,7 @@ def parseSubs(data):
         return subs
 
     def_subs = []
+    fb_subs = []
 
     for sub in data['subtitleUrls'] + data['forcedNarratives']:
         lang = sub['languageCode'].strip()
@@ -2140,8 +2137,13 @@ def parseSubs(data):
         if 'forced' in sub['displayName']:
             lang = lang + '.forced'
         sub['languageCode'] = lang
-        if sub_lang in lang:
+        if kodi_lang in lang:
             def_subs.append(sub)
+        if en_lang in lang:
+            fb_subs.append(sub)
+
+    if not def_subs:
+        def_subs = fb_subs
 
     import codecs
     for sub in def_subs:

--- a/plugin.video.amazon-test/default.py
+++ b/plugin.video.amazon-test/default.py
@@ -2111,11 +2111,7 @@ def parseSubs(data):
         'sv-se':'sv',
     } # Clean up language and locale information where needed
     subs = []
-<<<<<<< Updated upstream
-    if not down_lang or ('subtitleUrls' not in data and 'forcedNarratives' not in data):
-=======
     if (not down_lang) or (('subtitleUrls' not in data) and ('forcedNarratives' not in data)):
->>>>>>> Stashed changes
         return subs
 
     def_subs = []

--- a/plugin.video.amazon-test/resources/language/resource.language.de_de/strings.po
+++ b/plugin.video.amazon-test/resources/language/resource.language.de_de/strings.po
@@ -19,23 +19,23 @@ msgstr ""
 
 msgctxt "Addon Summary"
 msgid "Amazon Prime Video Streaming"
-msgstr "Amazon Prime Instant Video"
+msgstr "Amazon Prime Video"
 
 msgctxt "Addon Description"
 msgid "Movies and Television Shows for Prime Members"
-msgstr "Filme und Serien für Amazon Prime Mitglieder"
+msgstr "Filme und Serien für Prime-Mitglieder"
 
 msgctxt "Addon Disclaimer"
 msgid "Some parts of this addon may not be legal in your country of residence - please check with your local laws before installing.\nThis Addon uses pyDes by Todd Whiteman"
-msgstr "Möglicherweise sind einge Teile dieses Addons in Ihrem Land illegal, Sie sollten dies unbedingt vor der Installation überprüfen.\nDiese Addon verwendet pyDes von Todd Whiteman"
+msgstr "Möglicherweise sind einge Teile dieses Addons in Ihrem Land illegal, Sie sollten dies unbedingt vor der Installation überprüfen.\nDiese Erweiterung verwendet pyDes von Todd Whiteman"
 
 msgctxt "#30001"
 msgid "Amazon Account"
-msgstr "Amazon Zugangsdaten"
+msgstr "Amazon-Konto"
 
 msgctxt "#30002"
 msgid "Email Adress"
-msgstr "E-Mail Adresse"
+msgstr "E-Mail-Adresse"
 
 msgctxt "#30003"
 msgid "Password"
@@ -43,11 +43,11 @@ msgstr "Passwort"
 
 msgctxt "#30004"
 msgid "Stream Bitrate (0 - Ask)"
-msgstr "Stream Bitrate (0 - Fragen)"
+msgstr "Stream-Bitrate (0 - Fragen)"
 
 msgctxt "#30005"
 msgid "Subtitles languages"
-msgstr "Untertitel Sprachen"
+msgstr "Untertitel-Sprachen"
 
 msgctxt "#30006"
 msgid "Store Credentials instead of using the Cookie?"
@@ -63,7 +63,7 @@ msgstr "Anmelden…"
 
 msgctxt "#30009"
 msgid "Multi User Support"
-msgstr "Mehrbenutzer Unterstützung"
+msgstr "Mehrbenutzer-Unterstützung"
 
 msgctxt "#30010"
 msgid "Remove all Users"
@@ -79,7 +79,7 @@ msgstr "Wiedergabemethode"
 
 msgctxt "#30013"
 msgid "Inputstream Addon Settings…"
-msgstr "Inputstream Addon Einstellungen…"
+msgstr "Inputstream-Addon konfigurieren…"
 
 msgctxt "#30014"
 msgid "Logged in as"
@@ -91,11 +91,11 @@ msgstr "Ansicht"
 
 msgctxt "#30016"
 msgid "Movie Fanart Source"
-msgstr "Film-Fanart Quelle"
+msgstr "Film-Fanart-Quelle"
 
 msgctxt "#30017"
 msgid "TV Show Fanart Source"
-msgstr "Serien-Fanart Quelle"
+msgstr "Serien-Fanart-Quelle"
 
 msgctxt "#30018"
 msgid "Age restrictions…"
@@ -107,7 +107,7 @@ msgstr "Bevorzugter Host"
 
 msgctxt "#30020"
 msgid "Enable DRM check"
-msgstr "DRM Check aktivieren"
+msgstr "DRM-Überprüfung aktivieren"
 
 msgctxt "#30021"
 msgid "Switch Audiotrack, if not valid (experimental)"
@@ -127,27 +127,27 @@ msgstr "Alle"
 
 msgctxt "#30025"
 msgid "Kodi setting otherwise english"
-msgstr "Kodi Einstellungen ansonsten Englisch"
+msgstr "Kodi-Einstellungen sonst Englisch"
 
 msgctxt "#30026"
 msgid "Kodi setting otherwise all"
-msgstr "Kodi Einstellungen ansonsten alle"
+msgstr "Kodi-Einstellungen sonst alle"
 
 msgctxt "#30029"
 msgid "Movie View"
-msgstr "Film Ansicht"
+msgstr "Filmansicht"
 
 msgctxt "#30030"
 msgid "Show View"
-msgstr "Serien Ansicht"
+msgstr "Serienansicht"
 
 msgctxt "#30031"
 msgid "Season View"
-msgstr "Staffel Ansicht"
+msgstr "Staffel-Ansicht"
 
 msgctxt "#30032"
 msgid "Episode View"
-msgstr "Episoden Ansicht"
+msgstr "Episodenansicht"
 
 msgctxt "#30035"
 msgid "Enable Views"
@@ -171,7 +171,7 @@ msgstr "Vollbild aktivieren"
 
 msgctxt "#30042"
 msgid "Browser Kiosk Mode"
-msgstr "Browser Kiosk Modus"
+msgstr "Browser-Kioskmodus"
 
 msgctxt "#30043"
 msgid "Use custom Browser path"
@@ -183,7 +183,7 @@ msgstr "Wartezeit für Vollbild (sek)"
 
 msgctxt "#30045"
 msgid "Automatic PIN Input"
-msgstr "Automatische PIN Eingabe"
+msgstr "Automatische PIN-Eingabe"
 
 msgctxt "#30046"
 msgid "PIN"
@@ -191,15 +191,15 @@ msgstr "PIN"
 
 msgctxt "#30047"
 msgid "Wait after PIN Input"
-msgstr "Wartezeit nach PIN Eingabe"
+msgstr "Wartezeit nach PIN-Eingabe"
 
 msgctxt "#30048"
 msgid "Script path"
-msgstr "Scriptpfad"
+msgstr "Skriptpfad"
 
 msgctxt "#30049"
 msgid "Detect Framerate"
-msgstr "Framerate ermitteln"
+msgstr "Bildwiederholfrequenz ermitteln"
 
 msgctxt "#30050"
 msgid "Amazon"
@@ -207,7 +207,7 @@ msgstr "Amazon"
 
 msgctxt "#30051"
 msgid "Load missing from TMDb"
-msgstr "Fehlende von TMDb"
+msgstr "Fehlende von TMDb laden'"
 
 msgctxt "#30052"
 msgid "TMDb"
@@ -215,7 +215,7 @@ msgstr "Komplett von TMDb"
 
 msgctxt "#30053"
 msgid "Load missing from TVDb"
-msgstr "Fehlende von TVDb"
+msgstr "Fehlende von TVDb laden"
 
 msgctxt "#30054"
 msgid "TVDb"
@@ -231,7 +231,7 @@ msgstr "TVDb inkl. Poster"
 
 msgctxt "#30057"
 msgid "Wait till PIN Input"
-msgstr "Wartezeit bis PIN Eingabe"
+msgstr "Wartezeit bis PIN-Eingabe"
 
 msgctxt "#30059"
 msgid "Use own user profile"
@@ -279,15 +279,15 @@ msgstr "Bezahlinhalte anzeigen"
 
 msgctxt "#30074"
 msgid "Remote Control support"
-msgstr "Remote-Steuerung zulassen"
+msgstr "Fernsteuerung zulassen"
 
 msgctxt "#30075"
 msgid "UP/DOWN controls Kodi Volume"
-msgstr "HOCH/RUNTER regelt Kodi Lautstärke"
+msgstr "HOCH/RUNTER regelt Kodi-Lautstärke"
 
 msgctxt "#30076"
 msgid "Watchlist/Library Order"
-msgstr "Watchlist/Bibliothek Sortierung"
+msgstr "Watchlist-/Bibliothekssortierung"
 
 msgctxt "#30077"
 msgid "Recently Added"
@@ -327,7 +327,7 @@ msgstr "Bibliothek"
 
 msgctxt "#30101"
 msgid "Toogle Watched State"
-msgstr "Gesehen Status ändern"
+msgstr "Gesehen-Status ändern"
 
 msgctxt "#30102"
 msgid "Force Fallback"
@@ -363,7 +363,7 @@ msgstr "Sprache auswählen und wiedergeben"
 
 msgctxt "#30114"
 msgid "Choose Stream Quality:"
-msgstr "Stream Qualität auswählen:"
+msgstr "Stream-Qualität auswählen:"
 
 msgctxt "#30115"
 msgid "Available Languages:"
@@ -375,7 +375,7 @@ msgstr "PIN (leer für keine Abfrage)"
 
 msgctxt "#30121"
 msgid "PIN Request at"
-msgstr "PIN Abfrage ab"
+msgstr "PIN-Abfrage ab"
 
 msgctxt "#30122"
 msgid "Apply"
@@ -475,11 +475,11 @@ msgstr "Bibliothek aktualisieren"
 
 msgctxt "#30187"
 msgid "Source folders added/changed"
-msgstr "Amazon Video-Quellen hinzugefügt/geändert"
+msgstr "Video-Quellen hinzugefügt/geändert"
 
 msgctxt "#30188"
 msgid "To complete the setup:"
-msgstr "Zum Abschluß des Setups:"
+msgstr "Zum Abschluss der Einrichtung:"
 
 msgctxt "#30189"
 msgid " 1) Restart Kodi"
@@ -487,7 +487,7 @@ msgstr " 1) XBMC/Kodi neustarten"
 
 msgctxt "#30190"
 msgid " 2) Set the content type of added folders"
-msgstr " 2) den Inhalt der Ordner festlegen"
+msgstr " 2) Den Inhalt der Ordner festlegen"
 
 msgctxt "#30191"
 msgid "Restart"
@@ -495,7 +495,7 @@ msgstr "Neustart"
 
 msgctxt "#30192"
 msgid "Do you want to restart Kodi now?"
-msgstr "Soll der XBMC/Kodi neugestartet werden?"
+msgstr "Soll XBMC/Kodi neugestartet werden?"
 
 msgctxt "#30198"
 msgid "Browser or Script not found. Please check settings."
@@ -507,7 +507,7 @@ msgstr "Fehler bei der Anmeldung"
 
 msgctxt "#30201"
 msgid "Wrong Email Adress or Password"
-msgstr "E-Mail Adresse oder Passwort falsch"
+msgstr "E-Mail-Adresse oder Passwort falsch"
 
 msgctxt "#30202"
 msgid "No Search Results"
@@ -531,7 +531,7 @@ msgstr "Produkt nicht erworben"
 
 msgctxt "#30207"
 msgid "This Video is unavailable in your Country"
-msgstr "Dieses Video ist in Ihren Land nicht verfügbar"
+msgstr "Dieses Video ist in Ihrem Land nicht verfügbar"
 
 msgctxt "#30208"
 msgid "Playback currently not possible, try again later"
@@ -551,7 +551,7 @@ msgstr "Zugangsdaten und Cookie(s) entfernt"
 
 msgctxt "#30212"
 msgid "Captcha Request, please change IP or try again later"
-msgstr "Captcha Abfrage, bitte IP ändern oder später erneut versuchen"
+msgstr "Captcha-Abfrage, bitte IP-Adresse ändern oder später erneut versuchen"
 
 msgctxt "#30213"
 msgid "Unknown Error, please enable advanced debugging in settings and check avod-login.log/avod-login-si.log/avod-login-mfa.log"
@@ -567,12 +567,12 @@ msgstr "Anmeldung erfolgreich"
 
 msgctxt "#30216"
 msgid "No credentials present, please go to Settings-Connection and sign in"
-msgstr "Keine Zugangsdaten, bitte unter Einstellungen-Verbindung anmelden"
+msgstr "Keine Zugangsdaten, bitte unter Einstellungen>Verbindung anmelden"
 
 msgctxt "#30217"
 msgid "No stream hoster reachable"
-msgstr "Kein Stream Hoster verfügbar"
+msgstr "Kein Stream-Hoster verfügbar"
 
 msgctxt "#30218"
 msgid "Due changes at Amazon's DRM encryption, it's not possible to use Inputstream for this video.\nPlease configure the fallback option in Settings, to use another Playback method."
-msgstr "Wegen Änderung von Amazon's DRM Verschlüsselung, ist es nicht möglich dieses Video mittels Inputstream wiederzugeben.\nBitte eine alternative Wiedergabemethode in den Einstellungen unter Fallback konfigurieren."
+msgstr "Wegen Änderung von Amazons DRM-Verschlüsselung, ist es nicht möglich dieses Video mittels Inputstream wiederzugeben.\nBitte eine alternative Wiedergabemethode in den Einstellungen unter Fallback konfigurieren."

--- a/plugin.video.amazon-test/resources/language/resource.language.de_de/strings.po
+++ b/plugin.video.amazon-test/resources/language/resource.language.de_de/strings.po
@@ -126,11 +126,15 @@ msgid "All"
 msgstr "Alle"
 
 msgctxt "#30025"
-msgid "Kodi setting otherwise english"
-msgstr "Kodi-Einstellungen sonst Englisch"
+msgid "From Kodi player language settings"
+msgstr ""
 
 msgctxt "#30026"
-msgid "Kodi setting otherwise all"
+msgid "From settings, fallback to english"
+msgstr "Kodi-Einstellungen sonst Englisch"
+
+msgctxt "#30027"
+msgid "From settings, fallback to all"
 msgstr "Kodi-Einstellungen sonst alle"
 
 msgctxt "#30029"
@@ -300,26 +304,6 @@ msgstr "Titel aufsteigend"
 msgctxt "#30079"
 msgid "Title Descending"
 msgstr "Titel absteigend"
-
-msgctxt "#30080"
-msgid "Choose Country"
-msgstr "Land auswählen"
-
-msgctxt "#30081"
-msgid "Germany"
-msgstr "Deutschland"
-
-msgctxt "#30082"
-msgid "United Kingdom"
-msgstr "Großbritannien"
-
-msgctxt "#30083"
-msgid "USA"
-msgstr "USA"
-
-msgctxt "#30084"
-msgid "Japan"
-msgstr "Japan"
 
 msgctxt "#30100"
 msgid "Library"
@@ -576,3 +560,15 @@ msgstr "Kein Stream-Hoster verfügbar"
 msgctxt "#30218"
 msgid "Due changes at Amazon's DRM encryption, it's not possible to use Inputstream for this video.\nPlease configure the fallback option in Settings, to use another Playback method."
 msgstr "Wegen Änderung von Amazons DRM-Verschlüsselung, ist es nicht möglich dieses Video mittels Inputstream wiederzugeben.\nBitte eine alternative Wiedergabemethode in den Einstellungen unter Fallback konfigurieren."
+
+msgctxt "#30251"
+msgid "Connection error"
+msgstr ""
+
+msgctxt "#30252"
+msgid "Loading next page…"
+msgstr ""
+
+msgctxt "#30253"
+msgid "Found “{0}”"
+msgstr ""

--- a/plugin.video.amazon-test/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.amazon-test/resources/language/resource.language.en_gb/strings.po
@@ -126,18 +126,18 @@ msgid "All"
 msgstr ""
 
 msgctxt "#30025"
-msgid "From settings, fallback to english"
+msgid "From Kodi player language settings"
 msgstr ""
 
 msgctxt "#30026"
-msgid "From settings, fallback to all"
+msgid "From settings, fallback to english"
 msgstr ""
 
 msgctxt "#30027"
-msgid "Kodi setting otherwise only forced"
+msgid "From settings, fallback to all"
 msgstr ""
 
-#empty strings from id 30028 to 30029
+#empty string with id 30028
 
 msgctxt "#30029"
 msgid "Movie View"
@@ -317,53 +317,7 @@ msgctxt "#30079"
 msgid "Title Descending"
 msgstr ""
 
-msgctxt "#30080"
-msgid "Choose Country"
-msgstr ""
-
-msgctxt "#30081"
-msgid "Germany"
-msgstr ""
-
-msgctxt "#30082"
-msgid "United Kingdom"
-msgstr ""
-
-msgctxt "#30083"
-msgid "USA"
-msgstr ""
-
-msgctxt "#30084"
-msgid "Japan"
-msgstr ""
-
-msgctxt "#30085"
-msgid "Other (primevideo.com)"
-msgstr ""
-
-#empty strings from id 30086 to 30089
-
-msgctxt "#30090"
-msgid "PrimeVideo Area"
-msgstr ""
-
-msgctxt "#30091"
-msgid "ROE_EU"
-msgstr ""
-
-msgctxt "#30092"
-msgid "ROW_EU"
-msgstr ""
-
-msgctxt "#30093"
-msgid "ROW_FE"
-msgstr ""
-
-msgctxt "#30094"
-msgid "ROW_NA"
-msgstr ""
-
-#empty strings from id 30095 to 30099
+#empty strings from id 30080 to 30099
 
 msgctxt "#30100"
 msgid "Library"

--- a/plugin.video.amazon-test/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.amazon-test/resources/language/resource.language.en_gb/strings.po
@@ -126,11 +126,11 @@ msgid "All"
 msgstr ""
 
 msgctxt "#30025"
-msgid "Kodi setting otherwise english"
+msgid "From settings, fallback to english"
 msgstr ""
 
 msgctxt "#30026"
-msgid "Kodi setting otherwise all"
+msgid "From settings, fallback to all"
 msgstr ""
 
 msgctxt "#30027"

--- a/plugin.video.amazon/resources/language/German/strings.po
+++ b/plugin.video.amazon/resources/language/German/strings.po
@@ -19,11 +19,11 @@ msgstr ""
 
 msgctxt "Addon Summary"
 msgid "Amazon Prime Video Streaming"
-msgstr "Amazon Prime Instant Video"
+msgstr "Amazon Prime Video"
 
 msgctxt "Addon Description"
 msgid "Movies and Television Shows for Prime Members"
-msgstr "Filme und Serien für Amazon Prime Mitglieder"
+msgstr "Filme und Serien für Prime-Mitglieder"
 
 msgctxt "Addon Disclaimer"
 msgid "Some parts of this addon may not be legal in your country of residence - please check with your local laws before installing.\nThis Addon uses pyDes by Todd Whiteman"
@@ -31,11 +31,11 @@ msgstr "Möglicherweise sind einge Teile dieses Addons in Ihrem Land illegal, Si
 
 msgctxt "#30001"
 msgid "Amazon Account"
-msgstr "Amazon Zugangsdaten"
+msgstr "Amazon-Konto"
 
 msgctxt "#30002"
 msgid "Email Adress"
-msgstr "E-Mail Adresse"
+msgstr "E-Mail-Adresse"
 
 msgctxt "#30003"
 msgid "Password"
@@ -91,11 +91,11 @@ msgstr "Ansicht"
 
 msgctxt "#30016"
 msgid "Movie Fanart Source"
-msgstr "Film-Fanart Quelle"
+msgstr "Film-Fanart-Quelle"
 
 msgctxt "#30017"
 msgid "TV Show Fanart Source"
-msgstr "Serien-Fanart Quelle"
+msgstr "Serien-Fanart-Quelle"
 
 msgctxt "#30018"
 msgid "Daily"
@@ -127,7 +127,7 @@ msgstr "Sprache"
 
 msgctxt "#30027"
 msgid "Multi User Support"
-msgstr "Mehrbenutzer Unterstützung"
+msgstr "Mehrbenutzer-Unterstützung"
 
 msgctxt "#30028"
 msgid "Remove all Users"
@@ -135,19 +135,19 @@ msgstr "Alle Benutzer entfernen"
 
 msgctxt "#30029"
 msgid "Movie View"
-msgstr "Film Ansicht"
+msgstr "Filmansicht"
 
 msgctxt "#30030"
 msgid "Show View"
-msgstr "Serien Ansicht"
+msgstr "Serienansicht"
 
 msgctxt "#30031"
 msgid "Season View"
-msgstr "Staffel Ansicht"
+msgstr "Staffelansicht"
 
 msgctxt "#30032"
 msgid "Episode View"
-msgstr "Episoden Ansicht"
+msgstr "Episodenansicht"
 
 msgctxt "#30035"
 msgid "Enable Views"
@@ -155,7 +155,7 @@ msgstr "Ansichten aktivieren"
 
 msgctxt "#30036"
 msgid "Inputstream Addon Settings..."
-msgstr "Inputstream Addon Einstellungen..."
+msgstr "Inputstream-Addon konfigurieren..."
 
 msgctxt "#30037"
 msgid "Disable SSL Certificate Verification"
@@ -179,7 +179,7 @@ msgstr "Vollbild aktivieren"
 
 msgctxt "#30042"
 msgid "Browser Kiosk Mode"
-msgstr "Browser Kiosk Modus"
+msgstr "Browser-Kioskmodus"
 
 msgctxt "#30043"
 msgid "Use custom Browser path"
@@ -191,7 +191,7 @@ msgstr "Wartezeit für Vollbild (sek)"
 
 msgctxt "#30045"
 msgid "Automatic PIN Input"
-msgstr "Automatische PIN Eingabe"
+msgstr "Automatische PIN-Eingabe"
 
 msgctxt "#30046"
 msgid "PIN"
@@ -199,15 +199,15 @@ msgstr "PIN"
 
 msgctxt "#30047"
 msgid "Wait after PIN Input"
-msgstr "Wartezeit nach PIN Eingabe"
+msgstr "Wartezeit nach PIN-Eingabe"
 
 msgctxt "#30048"
 msgid "Script path"
-msgstr "Scriptpfad"
+msgstr "Skriptpfad"
 
 msgctxt "#30049"
 msgid "Detect Framerate"
-msgstr "Framerate ermitteln"
+msgstr "Bildwiederholfrequenz ermitteln"
 
 msgctxt "#30050"
 msgid "Amazon"
@@ -215,7 +215,7 @@ msgstr "Amazon"
 
 msgctxt "#30051"
 msgid "Load missing from TMDb"
-msgstr "Fehlende von TMDb"
+msgstr "Fehlende von TMDb laden"
 
 msgctxt "#30052"
 msgid "TMDb"
@@ -223,7 +223,7 @@ msgstr "Komplett von TMDb"
 
 msgctxt "#30053"
 msgid "Load missing from TVDb"
-msgstr "Fehlende von TVDb"
+msgstr "Fehlende von TVDb laden"
 
 msgctxt "#30054"
 msgid "TVDb"
@@ -271,7 +271,7 @@ msgstr "Bevorzugter Host"
 
 msgctxt "#30065"
 msgid "Enable DRM check"
-msgstr "DRM Check aktivieren"
+msgstr "DRM-Überprüfung aktivieren"
 
 msgctxt "#30066"
 msgid "Database system"
@@ -299,7 +299,7 @@ msgstr "Ausführliches Logging"
 
 msgctxt "#30073"
 msgid "Enable Remote Control"
-msgstr "Remote-Steuerung zulassen"
+msgstr "Fernsteuerung zulassen"
 
 msgctxt "#30074"
 msgid "Create Video Information File"
@@ -307,11 +307,11 @@ msgstr "Videoinfo-Datei erstellen"
 
 msgctxt "#30075"
 msgid "UP/DOWN controls Kodi Volume"
-msgstr "HOCH/RUNTER regelt Kodi Lautstärke"
+msgstr "HOCH/RUNTER regelt Kodi-Lautstärke"
 
 msgctxt "#30076"
 msgid "Watchlist/Library Order"
-msgstr "Watchlist/Bibliothek Sortierung"
+msgstr "Watchlist-/Bibliothekssortierung"
 
 msgctxt "#30077"
 msgid "Recently Added"
@@ -339,7 +339,7 @@ msgstr "Beliebt"
 
 msgctxt "#30101"
 msgid "Toggle watched state"
-msgstr "Gesehen Status ändern"
+msgstr "Gesehen-Status ändern"
 
 msgctxt "#30102"
 msgid "Full Movie Refresh(DB)"
@@ -555,7 +555,7 @@ msgstr "%s umbenennen"
 
 msgctxt "#30164"
 msgid "Refresh TVDB Data"
-msgstr "TVDB Daten aktualisieren"
+msgstr "TVDB-Daten aktualisieren"
 
 msgctxt "#30165"
 msgid "Lookup Show in TVDB"
@@ -635,11 +635,11 @@ msgstr "Bibliothek aktualisieren"
 
 msgctxt "#30187"
 msgid "Source folders added/changed"
-msgstr "Amazon Video-Quellen hinzugefügt/geändert"
+msgstr "Video-Quellen hinzugefügt/geändert"
 
 msgctxt "#30188"
 msgid "To complete the setup:"
-msgstr "Zum Abschluß des Setups:"
+msgstr "Zum Abschluß der Einrichtung:"
 
 msgctxt "#30189"
 msgid " 1) Restart Kodi"
@@ -647,7 +647,7 @@ msgstr " 1) Kodi neustarten"
 
 msgctxt "#30190"
 msgid " 2) Set the content type of added folders"
-msgstr " 2) den Inhalt der Ordner festlegen"
+msgstr " 2) Den Inhalt der Ordner festlegen"
 
 msgctxt "#30191"
 msgid "Restart"
@@ -679,7 +679,7 @@ msgstr "Fehler bei der Anmeldung"
 
 msgctxt "#30201"
 msgid "Wrong Email Adress or Password"
-msgstr "E-Mail Adresse oder Passwort falsch"
+msgstr "E-Mail-Adresse oder Passwort falsch"
 
 msgctxt "#30202"
 msgid "No Search Results"
@@ -703,7 +703,7 @@ msgstr "Produkt nicht erworben"
 
 msgctxt "#30207"
 msgid "This Video is unavailable in your Country"
-msgstr "Dieses Video ist in Ihren Land nicht verfügbar"
+msgstr "Dieses Video ist in Ihrem Land nicht verfügbar"
 
 msgctxt "#30208"
 msgid "Playback currently not possible, try again later"
@@ -723,7 +723,7 @@ msgstr "Zugangsdaten und Cookie(s) entfernt"
 
 msgctxt "#30212"
 msgid "Captcha Request, please change IP or try again later"
-msgstr "Captcha Abfrage, bitte IP ändern oder später erneut versuchen"
+msgstr "Captcha Abfrage, bitte IP-Adresse ändern oder später erneut versuchen"
 
 msgctxt "#30213"
 msgid "Unknown Error, please enable advanced debugging in settings and check amazon-login.log/amazon-login-si.log/amazon-login-mfa.log"
@@ -739,15 +739,15 @@ msgstr "Anmeldung erfolgreich"
 
 msgctxt "#30216"
 msgid "No credentials present, please go to Settings-Connection and sign in"
-msgstr "Keine Zugangsdaten, bitte unter Einstellungen-Verbindung anmelden"
+msgstr "Keine Zugangsdaten, bitte unter Einstellungen>Verbindung anmelden"
 
 msgctxt "#30217"
 msgid "No stream hoster reachable"
-msgstr "Kein Stream Hoster verfügbar"
+msgstr "Kein Stream-Hoster verfügbar"
 
 msgctxt "#30218"
 msgid "Due changes at Amazon's DRM encryption, it's not possible to use Inputstream for this video.\nPlease configure the fallback option in Settings, to use another Playback method."
-msgstr "Wegen Änderung der DRM Verschlüsselung bei Amazon, ist es nicht möglich dieses Video mittels Inputstream wiederzugeben.\nBitte eine alternative Wiedergabemethode in den Einstellungen unter Fallback konfigurieren."
+msgstr "Wegen Änderung der DRM-Verschlüsselung bei Amazon, ist es nicht möglich dieses Video mittels Inputstream wiederzugeben.\nBitte eine alternative Wiedergabemethode in den Einstellungen unter Fallback konfigurieren."
 
 msgctxt "#30220"
 msgid "PIN (empty for no restriction)"
@@ -755,7 +755,7 @@ msgstr "PIN (leer für keine Abfrage)"
 
 msgctxt "#30221"
 msgid "PIN Request at"
-msgstr "PIN Abfrage ab"
+msgstr "PIN-Abfrage ab"
 
 msgctxt "#30222"
 msgid "Apply"


### PR DESCRIPTION
Several improvements to subtitle handling and code readability (#113).

Adds support for the forced narrative subtitles, for the additional options from the Kodi `Player > Language > Subtitles` settings, and for the download of .srt files straight off amazon's servers (as hinted by @muphus).