### PR TITLE
Prevent reuse of language invoker

### DIFF
--- a/plugin.video.amazon/addon.xml
+++ b/plugin.video.amazon/addon.xml
@@ -32,6 +32,7 @@ This Addon uses pyDes by Todd Whiteman</disclaimer>
 Diese Addon verwendet pyDes von Todd Whiteman</disclaimer>
     <license>GNU GENERAL PUBLIC LICENSE. Version 2, June 1991</license>
     <forum>http://www.kodinerds.net/index.php/Thread/44211-Release-Amazon-Prime-Instant-Video</forum>
-    <source>https://github.com/Sandmann79/xbmc</source>    
+    <source>https://github.com/Sandmann79/xbmc</source>   
+    <reuselanguageinvoker>false</reuselanguageinvoker>	  
   </extension>
 </addon>


### PR DESCRIPTION
This prevents the reuse of the language invoker as described here:

https://github.com/xbmc/xbmc/pull/13814

It was merged and is already part of the last alpha. 

Reusing the language invoker does not call import statements in default.py hence the args array is not populated. This fixes this for now.