### PR TITLE
Workaround for enabling 1080p streaming from linux

### DIFF
--- a/plugin.video.amazon-test/resources/lib/network.py
+++ b/plugin.video.amazon-test/resources/lib/network.py
@@ -209,6 +209,8 @@ def getURLData(mode, asin, retformat='json', devicetypeid='AOAGZA014O5RE', versi
     url += '&format=' + retformat
     url += '&version=' + str(version)
     url += '&gascEnabled=' + str(g.UsePrimeVideo).lower()
+    if ('catalog/GetPlaybackResources' == mode):
+        url += '&operatingSystemName=Windows'
     if extra:
         url += '&resourceUsage=ImmediateConsumption&consumptionType=Streaming&deviceDrmOverride=CENC' \
                '&deviceStreamingTechnologyOverride=DASH&deviceProtocolOverride=Https' \


### PR DESCRIPTION
As per @Varstahl suggestion here: https://github.com/Sandmann79/xbmc/issues/218#issuecomment-449869366

This is working in official Kodi 18 Linux nightlies for streaming of Prime TV series in the US.

Also as suggested for this issue here: https://github.com/Sandmann79/xbmc/issues/205#issuecomment-450016441