### PR TITLE
Forbid retries on permanent errors

### DIFF
--- a/plugin.video.amazon-test/resources/lib/primevideo.py
+++ b/plugin.video.amazon-test/resources/lib/primevideo.py
@@ -471,7 +471,7 @@ class PrimeVideo(Singleton):
             couldNotParse = False
             try:
                 cnt = getURL(requestURL, silent=False, useCookie=True, rjson=False)
-                if 'lazyLoadURL' in o:
+                if (0 < len(cnt)) and ('lazyLoadURL' in o):
                     o['ref'] = o['lazyLoadURL']
                     del o['lazyLoadURL']
             except:
@@ -479,7 +479,7 @@ class PrimeVideo(Singleton):
             if couldNotParse or (0 == len(cnt)):
                 self._g.dialog.notification(getString(30251), requestURL, xbmcgui.NOTIFICATION_ERROR)
                 Log('Unable to fetch the url: {0}'.format(requestURL), Log.ERROR)
-                break
+                continue
 
             for t in [('\\\\n', '\n'), ('\\n', '\n'), ('\\\\"', '"'), (r'^\s+', '')]:
                 cnt = re.sub(t[0], t[1], cnt, flags=re.DOTALL)

--- a/plugin.video.amazon-test/resources/lib/primevideo.py
+++ b/plugin.video.amazon-test/resources/lib/primevideo.py
@@ -263,7 +263,9 @@ class PrimeVideo(Singleton):
                     if 'runtime' in m:
                         item.setInfo('video', {'duration': m['runtime']})
                         item.addStreamInfo('video', {'duration': m['runtime']})
-            xbmcplugin.addDirectoryItem(self._g.pluginhandle, url, item, isFolder=folder)
+            # If it's a video leaf without an actual video, something went wrong with Amazon servers, just hide it
+            if (not folder) or (4 > folderType):
+                xbmcplugin.addDirectoryItem(self._g.pluginhandle, url, item, isFolder=folder)
             del item
 
         # Set sort method and view


### PR DESCRIPTION
Fixes #228

@Sandmann79 after being notified of timeout/retries errors, I noticed that a part of our network stack within `getURL` was a bit messy:
* it retried cluelessly, even when it should absolutely not retry (eg: 404s)
* when `check=True` it would still retry once

On top of fixing those two issues, inside 12da226a7343a37159a6170d157bb5fa737aa6d2 I also changed the following:

* added a queryable static variable inside `getURL`, that would allow some sort of informed decision to be taken based on what HTTP status code was received (`lastResponseCode` would also be 0 in case of non-HTTP errors, there's also the possibility to expand with custom errors)
* refactored the hack-ish retry exception throws by adding two proper custom exceptions, `TryAgain` and `NoRetries`: retry on `408 Request Timeout`, `429 Too Many Requests` and `5xx server errors`; no retry in every other `4xx client error`. [Status codes reference](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes)
* increase the sleeping time by 10 seconds with every new retry attempt (10s first retry, 20s second retry, so on and so forth…)
* improved logging, for debugging purposes (upon 404 it would previously log both 404 followed by a more prominent 429, raising confusion)

I've tested various different HTTP status codes by pointing `getURL` at my servers, and everything seems to be in order. Before merging though I'll wait for the user feedback and your review, should I have misunderstood some of the code.

*Also*, while I'm at it, happy new year's day :) :fireworks: