### PR TITLE
Fix Amazon VOD login for accounts with Unicode characters in name.

### DIFF
--- a/plugin.video.amazon-test/resources/lib/network.py
+++ b/plugin.video.amazon-test/resources/lib/network.py
@@ -553,7 +553,7 @@ class _Captcha(pyxbmct.AddonDialogWindow):
             if not head:
                 head = soup.find('div', attrs={'id': 'message_error'})
             title = soup.find('div', attrs={'id': 'ap_captcha_guess_alert'})
-            self.head = head.p.renderContents().strip()
+            self.head = head.p.renderContents().strip().encode('utf-8')
             self.head = re.sub('(?i)<[^>]*>', '', self.head)
             self.picurl = soup.find('div', attrs={'id': 'ap_captcha_img'}).img.get('src')
         else:


### PR DESCRIPTION
The re.sub() call on the following line would fail with an UnicodeDecodeError
if attempting to login with an account with non-ASCII characters in their
registered name.