### PR TITLE
Add proxy service

### DIFF
--- a/plugin.video.amazon-test/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.amazon-test/resources/language/resource.language.en_gb/strings.po
@@ -26,7 +26,7 @@ msgid "Movies and Television Shows for Prime Members"
 msgstr ""
 
 msgctxt "Addon Disclaimer"
-msgid "Some parts of this addon may not be legal in your country of residence - please check with your local laws before installing.\nThis Addon uses pyDes by Todd Whiteman"
+msgid "Some parts of this addon may not be legal in your country of residence – please check with your local laws before installing.\nThis Addon uses pyDes by Todd Whiteman"
 msgstr ""
 
 msgctxt "#30001"
@@ -45,9 +45,7 @@ msgctxt "#30004"
 msgid "Stream Bitrate (0 - Ask)"
 msgstr ""
 
-msgctxt "#30005"
-msgid "Subtitles languages"
-msgstr ""
+#empty strings with id 30005
 
 msgctxt "#30006"
 msgid "Store Credentials instead of using the Cookie?"
@@ -109,33 +107,19 @@ msgctxt "#30020"
 msgid "Enable DRM check"
 msgstr ""
 
-#empty string with id 30021
+msgctxt "#30021"
+msgid "Language"
+msgstr ""
 
 msgctxt "#30022"
 msgid "Keep me logged in"
 msgstr ""
 
-msgctxt "#30023"
-msgid "None"
-msgstr ""
+#empty strings from id 30023 to id 30027
 
-msgctxt "#30024"
-msgid "All"
+msgctxt "#30028"
+msgid "Stretching"
 msgstr ""
-
-msgctxt "#30025"
-msgid "From Kodi player language settings"
-msgstr ""
-
-msgctxt "#30026"
-msgid "From settings, fallback to english"
-msgstr ""
-
-msgctxt "#30027"
-msgid "From settings, fallback to all"
-msgstr ""
-
-#empty string with id 30028
 
 msgctxt "#30029"
 msgid "Movie View"
@@ -153,13 +137,19 @@ msgctxt "#30032"
 msgid "Episode View"
 msgstr ""
 
-#empty strings from id 30033 to 30034
+msgctxt "#30033"
+msgid "Audio"
+msgstr ""
+
+msgctxt "#30034"
+msgid "Subtitles"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Enable Views"
 msgstr ""
 
-#empty strings id 30036
+#empty string with id 30036
 
 msgctxt "#30037"
 msgid "Disable SSL Certificate Verification"

--- a/plugin.video.amazon-test/resources/lib/common.py
+++ b/plugin.video.amazon-test/resources/lib/common.py
@@ -131,6 +131,7 @@ class Settings(Singleton):
     def __init__(self):
         self._g = Globals()
         self._gs = self._g.addon.getSetting
+        self._ss = self._g.addon.setSetting
 
     def __getattr__(self, name):
         if name in ['MOVIE_PATH', 'TV_SHOWS_PATH']:
@@ -166,6 +167,12 @@ class Settings(Singleton):
         elif 'OfferGroup' == name: return '' if self.payCont else '&OfferGroups=B0043YVHMY'
         elif 'wl_export' == name: return self._gs("wl_export") == 'true'
         elif 'region' == name: return int(self._gs("region"))
+
+    def get(self, name):
+        return self._gs(name)
+
+    def set(self, name, value):
+        return self._ss(name, value)
 
 
 def jsonRPC(method, props='', param=None):

--- a/plugin.video.amazon-test/resources/lib/common.py
+++ b/plugin.video.amazon-test/resources/lib/common.py
@@ -167,6 +167,7 @@ class Settings(Singleton):
         elif 'wl_export' == name: return self._gs('wl_export') == 'true'
         elif 'region' == name: return int(self._gs('region'))
         elif 'proxyaddress' == name: return getConfig('proxyaddress')
+        elif 'subtitleStretch' == name: return self._gs('sub_stretch') == 'true'
 
 
 def jsonRPC(method, props='', param=None):

--- a/plugin.video.amazon-test/resources/lib/common.py
+++ b/plugin.video.amazon-test/resources/lib/common.py
@@ -131,7 +131,6 @@ class Settings(Singleton):
     def __init__(self):
         self._g = Globals()
         self._gs = self._g.addon.getSetting
-        self._ss = self._g.addon.setSetting
 
     def __getattr__(self, name):
         if name in ['MOVIE_PATH', 'TV_SHOWS_PATH']:
@@ -145,34 +144,29 @@ class Settings(Singleton):
             l = xbmc.convertLanguage(l['value'], xbmc.ISO_639_1)
             l = l if l else xbmc.getLanguage(xbmc.ISO_639_1, False)
             return l if l else 'en'
-        elif 'playMethod' == name: return int(self._gs("playmethod"))
-        elif 'browser' == name: return int(self._gs("browser"))
-        elif 'MaxResults' == name: return int(self._gs("items_perpage"))
-        elif 'tvdb_art' == name: return self._gs("tvdb_art")
-        elif 'tmdb_art' == name: return self._gs("tmdb_art")
-        elif 'showfanart' == name: return self._gs("useshowfanart") == 'true'
-        elif 'dispShowOnly' == name: return self._gs("disptvshow") == 'true'
+        elif 'playMethod' == name: return int(self._gs('playmethod'))
+        elif 'browser' == name: return int(self._gs('browser'))
+        elif 'MaxResults' == name: return int(self._gs('items_perpage'))
+        elif 'tvdb_art' == name: return self._gs('tvdb_art')
+        elif 'tmdb_art' == name: return self._gs('tmdb_art')
+        elif 'showfanart' == name: return self._gs('useshowfanart') == 'true'
+        elif 'dispShowOnly' == name: return self._gs('disptvshow') == 'true'
         elif 'payCont' == name: return self._gs('paycont') == 'true'
         elif 'verbLog' == name: return self._gs('logging') == 'true'
-        elif 'useIntRC' == name: return self._gs("remotectrl") == 'true'
-        elif 'RMC_vol' == name: return self._gs("remote_vol") == 'true'
+        elif 'useIntRC' == name: return self._gs('remotectrl') == 'true'
+        elif 'RMC_vol' == name: return self._gs('remote_vol') == 'true'
         elif 'ms_mov' == name: ms_mov = self._gs('mediasource_movie'); return ms_mov if ms_mov else 'Amazon Movies'
         elif 'ms_tv' == name: ms_tv = self._gs('mediasource_tv'); return ms_tv if ms_tv else 'Amazon TV'
         elif 'multiuser' == name: return self._gs('multiuser') == 'true'
         elif 'DefaultFanart' == name: return OSPJoin(self._g.PLUGIN_PATH, 'fanart.jpg')
         elif 'NextIcon' == name: return OSPJoin(self._g.PLUGIN_PATH, 'resources', 'next.png')
         elif 'HomeIcon' == name: return OSPJoin(self._g.PLUGIN_PATH, 'resources', 'home.png')
-        elif 'wl_order' == name: return ['DATE_ADDED_DESC', 'TITLE_DESC', 'TITLE_ASC'][int('0' + self._gs("wl_order"))]
+        elif 'wl_order' == name: return ['DATE_ADDED_DESC', 'TITLE_DESC', 'TITLE_ASC'][int('0' + self._gs('wl_order'))]
         elif 'verifySsl' == name: return self._gs('ssl_verif') == 'false'
         elif 'OfferGroup' == name: return '' if self.payCont else '&OfferGroups=B0043YVHMY'
-        elif 'wl_export' == name: return self._gs("wl_export") == 'true'
-        elif 'region' == name: return int(self._gs("region"))
-
-    def get(self, name):
-        return self._gs(name)
-
-    def set(self, name, value):
-        return self._ss(name, value)
+        elif 'wl_export' == name: return self._gs('wl_export') == 'true'
+        elif 'region' == name: return int(self._gs('region'))
+        elif 'proxyaddress' == name: return getConfig('proxyaddress')
 
 
 def jsonRPC(method, props='', param=None):

--- a/plugin.video.amazon-test/resources/lib/network.py
+++ b/plugin.video.amazon-test/resources/lib/network.py
@@ -125,17 +125,13 @@ def getURL(url, useCookie=False, silent=False, headers=None, rjson=True, attempt
     # while every other response code is a specific HTTP status code
     getURL.lastResponseCode = 0
 
-    # Try to extract the host from the URL
-    host = re.search('://([^/]+)/', url)
-
     # Create sessions for keep-alives and connection pooling
+    host = re.search('://([^/]+)/', url)  # Try to extract the host from the URL
     if None is not host:
         host = host.group(1)
-        if host in getURL.sessions:
-            session = getURL.sessions[host]
-        else:
-            session = requests.Session()
-            getURL.sessions[host] = session
+        if host not in getURL.sessions:
+            getURL.sessions[host] = requests.Session()
+        session = getURL.sessions[host]
     else:
         session = requests.Session()
 
@@ -209,7 +205,9 @@ def getURL(url, useCookie=False, silent=False, headers=None, rjson=True, attempt
 
 
 def getURLData(mode, asin, retformat='json', devicetypeid='AOAGZA014O5RE', version=1, firmware='1', opt='', extra=False,
-               useCookie=False, retURL=False, vMT='Feature', dRes='PlaybackUrls,SubtitleUrls,ForcedNarratives'):
+               useCookie=False, retURL=False, vMT='Feature', dRes='PlaybackUrls,SubtitleUrls,ForcedNarratives', proxyEndpoint=None):
+    from urllib import quote_plus
+
     g = Globals()
     url = g.ATVUrl + '/cdp/' + mode
     url += '?asin=' + asin
@@ -234,7 +232,7 @@ def getURLData(mode, asin, retformat='json', devicetypeid='AOAGZA014O5RE', versi
     url += opt
     if retURL:
         return url
-    data = getURL(url, useCookie=useCookie, postdata='')
+    data = getURL(url if not proxyEndpoint else 'http://{}/{}/{}'.format(getConfig('proxyaddress'), proxyEndpoint, quote_plus(url)), useCookie=useCookie, postdata='')
     if data:
         if 'error' in data.keys():
             return False, _Error(data['error'])

--- a/plugin.video.amazon-test/resources/lib/playback.py
+++ b/plugin.video.amazon-test/resources/lib/playback.py
@@ -307,7 +307,7 @@ def PlayVideo(name, asin, adultstr, trailer, forcefb=0):
                     Log('Host not reachable: ' + cdn['cdn'])
                     continue
 
-                return (urlset['url'], subUrls) if retmpd else (True, _extrFr(data))
+                return ('http://{0}/mpd/{1}'.format(s.get('proxyaddress'), quote_plus(urlset['url'])), subUrls) if retmpd else (True, _extrFr(data))
 
         return False, getString(30217)
 

--- a/plugin.video.amazon-test/resources/lib/primevideo.py
+++ b/plugin.video.amazon-test/resources/lib/primevideo.py
@@ -157,7 +157,7 @@ class PrimeVideo(Singleton):
             self._catalog['root']['Watchlist'] = {'title': watchlist.group(3), 'lazyLoadURL': self._g.BaseUrl + watchlist.group(1)}
 
         # PrimeVideo.com top navigation menu
-        home = re.search('<div id="av-nav-main-menu".*?<ul role="navigation"[^>]*>\s*(.*?)\s*</ul>', home)
+        home = re.search(r'<div id="[ap]v-nav-main-menu".*?<ul role="navigation"[^>]*>\s*(.*?)\s*</ul>', home)
         if None is home:
             self._g.dialog.notification('PrimeVideo error', 'Unable to find the main primevideo.com navigation section', xbmcgui.NOTIFICATION_ERROR)
             Log('Unable to find the main primevideo.com navigation section', Log.ERROR)
@@ -650,18 +650,18 @@ class PrimeVideo(Singleton):
                         pagination = re.search(r'href="([^"]+)"\s*class="[^"]*u-pagination', cnt, flags=re.DOTALL)
                         if None is not pagination:
                             requestURLs.append((self._g.BaseUrl + pagination.group(1), o, refUrn))
-                elif None is not re.search('<div class="av-dp-container">', cnt, flags=re.DOTALL):
+                elif None is not re.search(r'<div class="[ap]v-dp-container">', cnt, flags=re.DOTALL):
                     ''' Movie/series page '''
                     # Are we getting the old or new version of the page?
                     bNewVersion = None is not re.search(r'<h1 [^>]*class="[^"]*DigitalVideoUI', cnt, flags=re.DOTALL)
 
                     # Find the biggest fanart available
-                    bgimg = re.search(r'<div class="av-hero-background[^"]*"[^>]*url\(([^)]+)\)', cnt, flags=re.DOTALL)
+                    bgimg = re.search(r'<div class="[ap]v-hero-background[^"]*"[^>]*url\(([^)]+)\)', cnt, flags=re.DOTALL)
                     if None is not bgimg:
                         bgimg = MaxSize(bgimg.group(1))
 
                     # Extract the global data
-                    gres = MultiRegexParsing(re.search(r'<section\s+[^>]*class="av-detail-section"[^>]*>\s*(.*?)\s*</section>', cnt, flags=re.DOTALL).group(1), {
+                    gres = MultiRegexParsing(re.search(r'<section\s+[^>]*class="[ap]v-detail-section"[^>]*>\s*(.*?)\s*</section>', cnt, flags=re.DOTALL).group(1), {
                         'cast': self._starringRex + r'\s*</dt>\s*<dd[^>]*>\s*(.*?)\s*</dd>',  # Starring
                         'director': self._directorRex + r'\s*</dt>\s*<dd[^>]*>\s*(.*?)\s*</dd>',  # Director
                         'genre': self._genresRex + r'\s*</dt>\s*<dd[^>]*>\s*(.*?)\s*</dd>',  # Genre
@@ -731,8 +731,8 @@ class PrimeVideo(Singleton):
                                 'id': r'<a data-automation-id="ep-playback-[0-9]+"[^>]*data-ref="([^"]*)"',
                                 'url': r'<a data-automation-id="ep-playback-[0-9]+"[^>]*data-ref="[^"]*"[^>]*data-title-id="[^"]*"[^>]*href="([^"]*)"',
                                 'asin': r'\s+data-title-id="\s*([^"]+?)\s*"',
-                                'image': r'<div class="av-bgimg__div"[^>]*url\(([^)]+)\)',
-                                'title': r'<span class="av-play-title-text">\s*(.*?)\s*</span>',
+                                'image': r'<div class="[ap]v-bgimg__div"[^>]*url\(([^)]+)\)',
+                                'title': r'<span class="[ap]v-play-title-text">\s*(.*?)\s*</span>',
                             })
                             res = MultiRegexParsing(entry, {
                                 'episode': r'id="ep-playback-([0-9]+)"',  # Episode number
@@ -783,8 +783,8 @@ class PrimeVideo(Singleton):
                                     if 'title' not in self._videodata[refUrn]:
                                         bSingle = None is not re.search(r'(av-season-single|DigitalVideoWebNodeDetail_seasons__single)', cnt, flags=re.DOTALL)
                                         self._videodata[refUrn]['title'] = Unescape(re.search([
-                                            r'<span class="av-season-single av-badge-text">\s*(.*?)\s*(?:</a>|</span>)',  # Old, single
-                                            r'<a class="av-droplist--selected"[^>]*>\s*(.*?)\s*</a>',  # Old, multi
+                                            r'<span class="[ap]v-season-single av-badge-text">\s*(.*?)\s*(?:</a>|</span>)',  # Old, single
+                                            r'<a class="[ap]v-droplist--selected"[^>]*>\s*(.*?)\s*</a>',  # Old, multi
                                             r'<span class="[^"]*DigitalVideoWebNodeDetail_seasons__single[^"]*"[^>]*>\s*<span[^>]*>\s*(.*?)\s*</span>',  # New, single
                                             r'<div class="[^*]*dv-node-dp-seasons.*?<label[^>]*>\s*<span[^>]*>\s*(.*?)\s*</span>\s*</label>',  # New, multi
                                         ][(2 if bNewVersion else 0) + (0 if bSingle else 1)], cnt, flags=re.DOTALL).group(1))
@@ -832,15 +832,15 @@ class PrimeVideo(Singleton):
                 else:
                     ''' Movie and series list '''
                     # Are we getting the old or new version of the list?
-                    bNewVersion = None is re.search(r'<li class="av-result-card">', cnt, flags=re.DOTALL)
+                    bNewVersion = None is re.search(r'<li class="[ap]v-result-card">', cnt, flags=re.DOTALL)
                     for entry in re.findall(r'<div class="[^"]*dvui-beardContainer[^"]*">\s*(.*?)\s*</form>\s*</div>\s*</div>\s*</div>'
-                                            if bNewVersion else r'<li class="av-result-card">\s*(.*?)\s*</li>',
+                                            if bNewVersion else r'<li class="[ap]v-result-card">\s*(.*?)\s*</li>',
                                             cnt, flags=re.DOTALL):
                         res = MultiRegexParsing(entry, {
                             'asin': r'\s+data-asin="\s*([^"]+?)\s*"',
                             'image': r'<a [^>]+><img\s+[^>]*src="([^"]+)"',
                             'link': r'<a href="([^"]+)"><img',
-                            'season': (r'<span>\s*' if bNewVersion else r'<span class="av-result-card-season">\s*') + self._seasonRex + r'\s+([0-9]+)\s*</span>',
+                            'season': (r'<span>\s*' if bNewVersion else r'<span class="[ap]v-result-card-season">\s*') + self._seasonRex + r'\s+([0-9]+)\s*</span>',
                             'title': r'<a class="' + (r'av-beard-title-link' if bNewVersion else r'av-result-card-title') + r'"[^>]*>\s*(.*?)\s*</a>',
                         })
                         NotifyUser(getString(30253).format(res['title']))
@@ -900,7 +900,7 @@ class PrimeVideo(Singleton):
 
                     # Next page
                     pagination = re.search(
-                        r'<li\s+[^>]*class="[^"]*av-pagination-current-page[^"]*"[^>]*>.*?</li>\s*<li\s+[^>]*class="av-pagination[^>]*>\s*(.*?)\s*</li>',
+                        r'<li\s+[^>]*class="[^"]*av-pagination-current-page[^"]*"[^>]*>.*?</li>\s*<li\s+[^>]*class="[ap]v-pagination[^>]*>\s*(.*?)\s*</li>',
                         cnt, flags=re.DOTALL)
                     if None is not pagination:
                         nru = Unescape(re.search(r'href="([^"]+)"', pagination.group(1), flags=re.DOTALL).group(1))

--- a/plugin.video.amazon-test/resources/lib/proxy.py
+++ b/plugin.video.amazon-test/resources/lib/proxy.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Author: Varstahl
+# Module: CryptoProxy
+# Created: 12/01/2019
+
+from __future__ import unicode_literals
+import base64
+from SocketServer import TCPServer
+from resources.lib.logging import Log
+try:
+    from BaseHTTPServer import BaseHTTPRequestHandler  # Python2 HTTP Server
+except ImportError:
+    from http.server import BaseHTTPRequestHandler  # Python3 HTTP Server
+
+
+class ProxyHTTPD(BaseHTTPRequestHandler):
+    def log_message(self, *args):
+        """Disable the BaseHTTPServer Log"""
+        pass
+
+    def _AdjustLocale(self, p1, p2):
+        """Locale conversion helper"""
+        localeConversionTable = {
+            'ar-001': 'ar',
+            'cmn-HANS': 'zh-HANS',
+            'cmn-HANT': 'zh-HANT',
+            'da-DK': 'da',
+            'es-419': 'es-Latinoamerica',
+            'ja-JP': 'ja',
+            'ko-KR': 'ko',
+            'nb-NO': 'nb',
+            'sv-SE': 'sv',
+            'pt-BR': 'pt-Brazil'
+        }
+        new_lang = p1 + ('' if p1 == p2 else '-' + p2.upper())
+        if new_lang in localeConversionTable.keys():
+            new_lang = localeConversionTable[new_lang]
+        return new_lang
+
+    def _ParseBaseRequest(self):
+        """Return path, headers and post data commonly required by all methods"""
+        from resources.lib.network import MechanizeLogin
+        from urlparse import unquote, urlparse, parse_qsl
+
+        path = urlparse(self.path).path[1:]  # Get URI without the trailing slash
+        path = path.split('/')  # license/<asin>/<ATV endpoint>
+        Log('[PS] Requested path {}'.format(path), Log.DEBUG)
+
+        # Retrieve headers, data and set up cookies for the forward
+        cookie = MechanizeLogin()
+        if not cookie:
+            Log('[PS] Not logged in', Log.DEBUG)
+            self.send_response(400)
+            return (None, None, None)
+        headers = {k: self.headers[k] for k in self.headers if k not in ['host', 'content-length']}
+        headers['cookie'] = ';'.join(['%s=%s' % (k, v) for k, v in cookie.items()])
+        data_length = self.headers.get('content-length')
+        data = None if None is data_length else {k: v for k, v in parse_qsl(self.rfile.read(int(data_length)))}
+        return (path, headers, data)
+
+    def _ForwardRequest(self, method, endpoint, headers, data=None):
+        """Forwards the request to the proper target"""
+        import requests
+        r = requests.request(method, endpoint, data=data, headers=headers, verify=self.server._s.verifySsl)
+        return (r.status_code, r.headers, r.content)
+
+    def _SendResponse(self, code, headers, content):
+        """Send a response to the caller"""
+        # We don't use chunked or gunzipped transfers locally, so we removed the relative headers and
+        # attach the contact length, before returning the response
+        headers = {k: headers[k] for k in headers if k not in ['Transfer-Encoding', 'Content-Encoding']}
+        headers['Content-Length'] = len(content)
+
+        # Build the response
+        self.send_response(code)
+        for k in headers:
+            self.send_header(k, headers[k])
+        self.end_headers()
+        self.wfile.write(content)
+
+    def do_POST(self):
+        """Respond to POST requests"""
+        from urlparse import unquote
+
+        Log('[PS] Invalid request received', Log.DEBUG)
+        self.send_response(501)
+        return
+
+    def do_GET(self):
+        """Respond to GET requests"""
+        from urlparse import unquote, urlparse
+        import re
+
+        path, headers, data = self._ParseBaseRequest()
+
+        if None is path:
+            return
+
+        if ('mpd' == path[0]) and (2 == len(path)):
+            endpoint = unquote(path[1])  # MPD stream
+
+            # Extrapolate the base CDN url to avoid proxying data we don't need to
+            url_parts = urlparse(endpoint)
+            baseurl = url_parts.scheme + '://' + url_parts.netloc + re.sub(r'[^/]+$', '', url_parts.path)
+            status_code, headers, content = self._ForwardRequest('get', endpoint, headers)  # Call the destination server
+
+            content = re.sub(r'(<BaseURL>)', r'\1{}'.format(baseurl), content)  # Rebase CDN URLs
+            header, sets, footer = re.search(r'^(.*<Period [^>]*>\s*)(.*)(\s*</Period>.*)$', content, flags=re.DOTALL).groups()  # Extract <AdaptationSet>s
+
+            # Alter the <AdaptationSet>s for our linguistic needs
+            new_sets = []
+            for s in re.findall(r'(<AdaptationSet\s+[^>]*>)(.*?</AdaptationSet>)', content, flags=re.DOTALL):
+                audioTrack = re.search(r' audioTrackId="([a-z]{2})-([a-z0-9]{2,})[^"]+[^>]+ lang="([a-z]{2})"', s[0])
+                new_sets.append((s[0] if None is audioTrack else s[0].replace('lang="{}"'.format(audioTrack.group(3)), 'lang="{}"'.format(self._AdjustLocale(audioTrack.group(1), audioTrack.group(2))))) + s[1])
+
+            content = header + ''.join(new_sets) + footer  # Reassemble the MPD
+        else:
+            Log('[PS] Invalid request received', Log.DEBUG)
+            self.send_response(501)
+            return
+
+        self._SendResponse(status_code, headers, content)
+
+
+class ProxyTCPD(TCPServer):
+    def __init__(self, settings):
+        """ Initialisation of the Proxy TCP server """
+        self._s = settings  # Make settings available to the RequestHandler
+
+        from socket import socket, AF_INET, SOCK_STREAM
+        sock = socket(AF_INET, SOCK_STREAM)
+        sock.bind(('127.0.0.1', 0))
+        _, port = sock.getsockname()
+        sock.close()
+        self.port = port  # Save the current binded port
+
+        TCPServer.__init__(self, ('127.0.0.1', port), ProxyHTTPD)

--- a/plugin.video.amazon-test/resources/lib/proxy.py
+++ b/plugin.video.amazon-test/resources/lib/proxy.py
@@ -6,7 +6,7 @@
 
 from __future__ import unicode_literals
 import base64
-from SocketServer import TCPServer
+from SocketServer import ThreadingTCPServer
 from resources.lib.logging import Log
 try:
     from BaseHTTPServer import BaseHTTPRequestHandler  # Python2 HTTP Server
@@ -15,43 +15,51 @@ except ImportError:
 
 
 class ProxyHTTPD(BaseHTTPRequestHandler):
+    protocol_version = 'HTTP/1.1'  # Allow keep-alive
+    server_version = 'AmazonVOD/0.1'
+    sessions = {}  # Keep-Alive sessions
+
     def log_message(self, *args):
         """Disable the BaseHTTPServer Log"""
         pass
 
-    def _AdjustLocale(self, p1, p2):
+    def _AdjustLocale(self, langCode, separator='-'):
         """Locale conversion helper"""
+        try:
+            p1, p2 = langCode.split('-')
+        except:
+            p1 = langCode
+            p2 = langCode
         localeConversionTable = {
-            'ar-001': 'ar',
-            'cmn-HANS': 'zh-HANS',
-            'cmn-HANT': 'zh-HANT',
-            'da-DK': 'da',
-            'es-419': 'es-Latinoamerica',
-            'ja-JP': 'ja',
-            'ko-KR': 'ko',
-            'nb-NO': 'nb',
-            'sv-SE': 'sv',
-            'pt-BR': 'pt-Brazil'
+            'ar' + separator + '001': 'ar',
+            'cmn' + separator + 'HANS': 'zh' + separator + 'HANS',
+            'cmn' + separator + 'HANT': 'zh' + separator + 'HANT',
+            'da' + separator + 'DK': 'da',
+            'es' + separator + '419': 'es' + separator + 'Latinoamerica',
+            'ja' + separator + 'JP': 'ja',
+            'ko' + separator + 'KR': 'ko',
+            'nb' + separator + 'NO': 'nb',
+            'sv' + separator + 'SE': 'sv',
+            'pt' + separator + 'BR': 'pt' + separator + 'Brazil'
         }
-        new_lang = p1 + ('' if p1 == p2 else '-' + p2.upper())
-        if new_lang in localeConversionTable.keys():
-            new_lang = localeConversionTable[new_lang]
+        new_lang = p1 + ('' if p1 == p2 else separator + p2.upper())
+        new_lang = new_lang if new_lang not in localeConversionTable.keys() else localeConversionTable[new_lang]
         return new_lang
 
-    def _ParseBaseRequest(self):
+    def _ParseBaseRequest(self, method):
         """Return path, headers and post data commonly required by all methods"""
         from resources.lib.network import MechanizeLogin
         from urlparse import unquote, urlparse, parse_qsl
 
         path = urlparse(self.path).path[1:]  # Get URI without the trailing slash
         path = path.split('/')  # license/<asin>/<ATV endpoint>
-        Log('[PS] Requested path {}'.format(path), Log.DEBUG)
+        Log('[PS] Requested {} path {}'.format(method, path), Log.DEBUG)
 
         # Retrieve headers, data and set up cookies for the forward
         cookie = MechanizeLogin()
         if not cookie:
             Log('[PS] Not logged in', Log.DEBUG)
-            self.send_response(400)
+            self.send_error(440)
             return (None, None, None)
         headers = {k: self.headers[k] for k in self.headers if k not in ['host', 'content-length']}
         headers['cookie'] = ';'.join(['%s=%s' % (k, v) for k, v in cookie.items()])
@@ -61,8 +69,20 @@ class ProxyHTTPD(BaseHTTPRequestHandler):
 
     def _ForwardRequest(self, method, endpoint, headers, data=None):
         """Forwards the request to the proper target"""
+        import re
         import requests
-        r = requests.request(method, endpoint, data=data, headers=headers, verify=self.server._s.verifySsl)
+
+        # Create sessions for keep-alives and connection pooling
+        host = re.search('://([^/]+)/', endpoint)  # Try to extract the host from the URL
+        if None is not host:
+            host = host.group(1)
+            if host not in self.sessions:
+                self.sessions[host] = requests.Session()
+            session = self.sessions[host]
+        else:
+            session = requests.Session()
+
+        r = session.request(method, endpoint, data=data, headers=headers, verify=self.server._s.verifySsl)
         return (r.status_code, r.headers, r.content)
 
     def _SendResponse(self, code, headers, content):
@@ -83,19 +103,53 @@ class ProxyHTTPD(BaseHTTPRequestHandler):
         """Respond to POST requests"""
         from urlparse import unquote
 
-        Log('[PS] Invalid request received', Log.DEBUG)
-        self.send_response(501)
-        return
+        path, headers, data = self._ParseBaseRequest('POST')
+        if None is path: return
+
+        if ('gpr' == path[0]) and (2 == len(path)):
+            # Alter the GetPlaybackResources manifest
+            from urllib import quote_plus
+            import json
+            import xbmc
+            endpoint = unquote(path[1])  # MPD stream
+            status_code, headers, content = self._ForwardRequest('get', endpoint, headers)
+
+            # Grab the subtitle urls, merge them in a single list, append the locale codes to let Kodi figure
+            # out which URL has which language, then sort them neatly in a human digestible order.
+            content = json.loads(content)
+            content['subtitles'] = []
+            for sub_type in ['forcedNarratives', 'subtitleUrls']:
+                if sub_type in content:
+                    for i in range(0, len(content[sub_type])):
+                        fn = self._AdjustLocale(content[sub_type][i]['languageCode'], ' ')
+                        variants = '{}{}'.format(
+                            ' [CC]' if 'sdh' == content[sub_type][i]['type'] else '',
+                            '.Forced' if 'forcedNarratives' == sub_type else ''
+                        )
+                        # Proxify the URLs, with a make believe Kodi-friendly file name
+                        content[sub_type][i]['url'] = 'http://127.0.0.1:{}/subtitles/{}/{}.srt'.format(
+                            self.server.port,
+                            quote_plus(content[sub_type][i]['url']),
+                            '{}{}'.format(fn, variants)
+                        )
+                        content['subtitles'].append((content[sub_type][i], xbmc.convertLanguage(fn[0:2], xbmc.ENGLISH_NAME).decode('utf-8') + fn, variants))
+                del content[sub_type]  # Reduce the data transfer by removing the lists we merged
+            content['subtitles'] = [x[0] for x in sorted(content['subtitles'], key=lambda sub: (sub[1], sub[2]))]
+            content = json.dumps(content)
+        else:
+            Log('[PS] Invalid request received', Log.DEBUG)
+            self.send_error(501, 'Invalid request')
+            return
+
+        self._SendResponse(status_code, headers, content)
 
     def do_GET(self):
         """Respond to GET requests"""
         from urlparse import unquote, urlparse
         import re
 
-        path, headers, data = self._ParseBaseRequest()
-
-        if None is path:
-            return
+        path, headers, data = self._ParseBaseRequest('GET')
+        if None is path: return
 
         if ('mpd' == path[0]) and (2 == len(path)):
             endpoint = unquote(path[1])  # MPD stream
@@ -111,19 +165,45 @@ class ProxyHTTPD(BaseHTTPRequestHandler):
             # Alter the <AdaptationSet>s for our linguistic needs
             new_sets = []
             for s in re.findall(r'(<AdaptationSet\s+[^>]*>)(.*?</AdaptationSet>)', content, flags=re.DOTALL):
-                audioTrack = re.search(r' audioTrackId="([a-z]{2})-([a-z0-9]{2,})[^"]+[^>]+ lang="([a-z]{2})"', s[0])
-                new_sets.append((s[0] if None is audioTrack else s[0].replace('lang="{}"'.format(audioTrack.group(3)), 'lang="{}"'.format(self._AdjustLocale(audioTrack.group(1), audioTrack.group(2))))) + s[1])
+                audioTrack = re.search(r' audioTrackId="([a-z]{2}-[a-z0-9]{2,})[^"]+[^>]+ lang="([a-z]{2})"', s[0])
+                new_sets.append((s[0] if None is audioTrack else s[0].replace('lang="%s"' % audioTrack.group(2), 'lang="%s"' % self._AdjustLocale(audioTrack.group(1)))) + s[1])
 
             content = header + ''.join(new_sets) + footer  # Reassemble the MPD
+        elif ('subtitles' == path[0]) and (3 == len(path)):
+            # On-the-fly subtitle transcoding (TTMLv2 => SRT)
+            status_code, headers, content = self._ForwardRequest('get', unquote(path[1]), headers)
+            if 0 < len(content):
+                # Apply a bunch of regex to the content instead of line-by-line to save computation time
+                content = re.sub(r'<(|/)span[^>]*>', r'<\1i>', content.decode('utf-8'))  # Using (|<search>) instead of ()? to avoid py2.7 empty matching error
+                content = re.sub(r'([0-9]{2}:[0-9]{2}:[0-9]{2})\.', r'\1,', content)  # SRT-like timestamps
+                content = re.sub(r'\s*<(?:tt:)?br\s*/>\s*', '\n', content)  # Replace <br/> with actual new lines
+
+                # Convert dfxp or ttml2 to srt
+                num = 0
+                srt = ''
+                for tt in re.compile(r'<(?:tt:)?p begin="([^"]+)"[^>]*end="([^"]+)"[^>]*>\s*(.*?)\s*</(?:tt:)?p>', re.DOTALL).findall(content):
+                    text = tt[2]
+
+                    # Embed RTL and change the punctuation where needed
+                    if path[2].startswith("ar"):
+                        from unicodedata import lookup
+                        text = re.sub('^', lookup('RIGHT-TO-LEFT EMBEDDING'), text, flags=re.MULTILINE)
+                        text = text.replace('?', '؟').replace(',', '،')
+
+                    for ec in [('&amp;', '&'), ('&quot;', '"'), ('&lt;', '<'), ('&gt;', '>'), ('&apos;', "'")]:
+                        text = text.replace(ec[0], ec[1])
+                    num += 1
+                    srt += '%s\n%s --> %s\n%s\n\n' % (num, tt[0], tt[1], text)
+                content = srt.encode('utf-8')
         else:
             Log('[PS] Invalid request received', Log.DEBUG)
-            self.send_response(501)
+            self.send_error(501, 'Invalid request')
             return
 
         self._SendResponse(status_code, headers, content)
 
 
-class ProxyTCPD(TCPServer):
+class ProxyTCPD(ThreadingTCPServer):
     def __init__(self, settings):
         """ Initialisation of the Proxy TCP server """
         self._s = settings  # Make settings available to the RequestHandler
@@ -135,4 +215,4 @@ class ProxyTCPD(TCPServer):
         sock.close()
         self.port = port  # Save the current binded port
 
-        TCPServer.__init__(self, ('127.0.0.1', port), ProxyHTTPD)
+        ThreadingTCPServer.__init__(self, ('127.0.0.1', port), ProxyHTTPD)

--- a/plugin.video.amazon-test/resources/settings.xml
+++ b/plugin.video.amazon-test/resources/settings.xml
@@ -3,43 +3,59 @@
     <category label="30011">
         <setting id="playmethod" type="enum" label="30012" values="Browser|Script/Batch|Android|Input Stream" default="3"/>
         <setting type="sep"/>
+        <!-- Browser/Script -->
         <setting id="browser" type="enum" label="Browser" values="Internet Explorer|Chrome|Firefox|Safari" default="0" visible="lt(-2,2)"/>
+        <!-- Browser -->
         <setting id="cust_path" type="bool" label="30043" default="" visible="eq(-3,0)"/>
         <setting id="br_path" type="file" label="30062" default="" visible="eq(-4,0)" enable="eq(-1,true)" subsetting="true"/>
-        <setting id="scr_path" type="file" label="30048" default="" visible="eq(-5,1)"/>
-        <setting id="scr_param" type="text" label="Parameter ({u} - URL / {f} - Framerate)" default="{f} &quot;{u}&quot;" visible="eq(-6,1)"/>
-        <setting id="framerate" type="bool" label="30049" default="true" visible="eq(-7,1)" />
-        <setting id="ownappdata" type="bool" label="30059" default="false" visible="eq(-8,0)" enable="gt(-6,0) + lt(-6,3)"/>
-        <setting id="kiosk" type="bool" label="30042" default="true" visible="eq(-9,0)" enable="!eq(-7,2) + !eq(-7,3)"/>
+        <setting id="ownappdata" type="bool" label="30059" default="false" visible="eq(-5,0)" enable="gt(-3,0) + lt(-3,3)"/>
+        <setting id="kiosk" type="bool" label="30042" default="true" visible="eq(-6,0)" enable="!eq(-4,2) + !eq(-4,3)"/>
+        <!-- Script -->
+        <setting id="scr_path" type="file" label="30048" default="" visible="eq(-7,1)"/>
+        <setting id="scr_param" type="text" label="Parameter ({u} - URL / {f} - Framerate)" default="{f} &quot;{u}&quot;" visible="eq(-8,1)"/>
+        <setting id="framerate" type="bool" label="30049" default="true" visible="eq(-9,1)" />
+        <!-- - -->
         <setting type="sep"/>
+        <!-- Browser/Script -->
         <setting id="fullscreen" type="bool" label="30041" default="false" visible="lt(-11,2)"/>
         <setting id="clickwait" type="labelenum" values="1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30" label="30044" default="10" enable="eq(-1,true)" visible="lt(-12,2)"/>
         <setting id="pininput" type="bool" label="30045" default="false" visible="lt(-13,2)" />
         <setting id="pin" type="number" label="30046" enable="eq(-1,true)" default="" visible="lt(-14,2)" />
         <setting id="waitprepin" type="labelenum" values="1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30" label="30057" default="10" visible="eq(-4,false) + lt(-15,2)" enable="eq(-2,true) + eq(-4,false)"/>
         <setting id="waitpin" type="labelenum" values="1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30" enable="eq(-3,true) + eq(-5,true)" label="30047" default="5" visible="eq(-5,true) + lt(-16,2)"/>
-        <setting id="sub_lang" type="enum" label="30005" visible="eq(-17,3)" default="0" lvalues='30023|30024|30025|30026|30027'/>
-        <setting id="pref_host" type="labelenum" label="30019" visible="eq(-18,3)" values="Auto|Akamai|Cloudfront|Level3|Limelight" default="Auto"/>
-        <setting id="is_settings" type="action" label="30013" visible="eq(-19,3)" action="RunPlugin(plugin://plugin.video.amazon-test/?mode=openSettings&url=is)" option="close"/>
-        <setting id="age_settings" type="action" label="30018" visible="eq(-20,3)" action="RunPlugin(plugin://plugin.video.amazon-test/?mode=ageSettings)" option="close"/>
-        <setting id="drm_check" type="bool" label="30020" visible="eq(-21,3)" default="true"/>
-        <setting id="fallback_method" type="enum" label="Fallback" values="None|Browser|Script/Batch|Android" default="0" visible="eq(-22,3)" enable="eq(-1,true)" subsetting="true"/>
+        <!-- Inputstream -->
+        <setting id="pref_host" type="labelenum" label="30019" visible="eq(-17,3)" values="Auto|Akamai|Cloudfront|Level3|Limelight" default="Auto"/>
+        <setting id="is_settings" type="action" label="30013" visible="eq(-18,3)" action="RunPlugin(plugin://plugin.video.amazon-test/?mode=openSettings&url=is)" option="close"/>
+        <setting id="age_settings" type="action" label="30018" visible="eq(-19,3)" action="RunPlugin(plugin://plugin.video.amazon-test/?mode=ageSettings)" option="close"/>
+        <setting id="drm_check" type="bool" label="30020" visible="eq(-20,3)" default="true"/>
+        <setting id="fallback_method" type="enum" label="Fallback" values="None|Browser|Script/Batch|Android" default="0" visible="eq(-21,3)" enable="eq(-1,true)" subsetting="true"/>
     </category>
+    <!-- Connection -->
+    <category label="30021">
+        <setting label="30034" type="lsep"/>
+        <setting id="sub_stretch" type="bool" label="30028" default="false"/>
+    </category>
+    <!-- Connection -->
     <category label="30038">
         <setting id="ssl_verif" type="bool" label="30037" default="false"/>
         <setting id="items_perpage" type="labelenum" values="20|30|40|60|80|100|140|180|220|250" label="30039" default="40"/>
+        <!-- - -->
         <setting label="30001" type="lsep"/>
         <setting id="region" type="enum" label="Region" values="Auto|Germany|United Kingdom|USA|Japan|ROE Europe|ROW Europe|ROW Far East|ROW North America" default="0" />
         <setting id="multiuser" type="bool" label="30009" default="false"/>
         <setting id="rememberme" type="bool" label="30022" default="true"/>
+        <!-- Multiuser -->
         <setting type="action" label="30130" action="RunPlugin(plugin://plugin.video.amazon-test/?mode=LogIn)" visible="eq(-2,true)" option="close" />
         <setting type="action" label="30131" action="RunPlugin(plugin://plugin.video.amazon-test/?mode=removeUser)" visible="eq(-3,true)" option="close"/>
         <setting type="action" label="30008" action="RunPlugin(plugin://plugin.video.amazon-test/?mode=LogIn)" option="close" visible="eq(-4,false)"/>
         <setting id="login_acc" type="text" label="30014" enable="false" default="" subsetting="true" visible="eq(-5,false)"/>
+        <!-- /Multiuser -->
         <setting id="save_login" type="bool" label="30006" default="false"/>
+        <!-- Multiuser -->
         <setting label="30007" type="action" action="RunPlugin(plugin://plugin.video.amazon-test/?mode=remLoginData)" option="close" visible="eq(-7,false)"/>
         <setting label="30010" type="action" action="RunPlugin(plugin://plugin.video.amazon-test/?mode=remLoginData)" option="close" visible="eq(-8,true)"/>
     </category>
+    <!-- Views -->
     <category label="30015">
         <setting id="viewenable" type ="bool" label="30035" default="false"/>
         <setting id="movieview" type="enum" values="List|Poster|IconWall|Shift|InfoWall|WideList|Wall|Banner|FanArt|Custom" label="30029" default="5" enable="eq(-1,true)" />
@@ -51,6 +67,7 @@
         <setting id="episodeview" type="enum" values="List|Poster|IconWall|Shift|InfoWall|WideList|Wall|Banner|FanArt|Custom" label="30032" default="3" enable="eq(-7,true)"/>
         <setting id="episodeid" type="number" label="View ID" enable="eq(-1,9) + eq(-8,true)" subsetting="true" />
     </category>
+    <!-- Export -->
     <category label="30060">
         <setting id="enablelibraryfolder" type="bool" label="30061" default="false" />
         <setting id="customlibraryfolder" type="folder" label="30062" enable="eq(-1,true)" default="special://profile/addon_data/plugin.video.amazon-test" source="auto" option="writeable" subsetting="true" />
@@ -58,11 +75,13 @@
         <setting id="mediasource_movie" type="text" label="30064" default="Amazon Movies" />
         <setting id="mediasource_tv" type="text" label="30065" default="Amazon TV" />
     </category>
+    <!-- Miscellaneous -->
     <category label="30070">
         <setting label="Fanart" type="lsep"/>
         <setting id="tmdb_art" type="enum" lvalues="30050|30051|30052" label="30016" default="1"/>
         <setting id="tvdb_art" type="enum" lvalues="30050|30053|30054|30056" label="30017" default="1"/>
         <setting id="useshowfanart" type="bool" label="30055" default="true"/>
+        <!-- - -->
         <setting label="30070" type="lsep"/>
         <setting id="paycont" type="bool" label="30073" default="false"/>
         <setting id="disptvshow" type="bool" label="30071" default="false"/>

--- a/plugin.video.amazon-test/service.py
+++ b/plugin.video.amazon-test/service.py
@@ -16,11 +16,12 @@ class BackgroundService():
     def __init__(self):
         from resources.lib.common import Settings
         from resources.lib.proxy import ProxyTCPD
+        from resources.lib.configs import writeConfig
         self._s = Settings()
         self.lastExport = float(getConfig('last_wl_export', '0'))
         self.proxy = ProxyTCPD(self._s)
-        self._s.set('proxyaddress', '127.0.0.1:{}'.format(self.proxy.port))
-        Log('Service: Proxy bound to {}'.format(self._s.get('proxyaddress')))
+        writeConfig('proxyaddress', '127.0.0.1:{}'.format(self.proxy.port))
+        Log('Service: Proxy bound to {}'.format(self._s.proxyaddress))
         self.proxy_thread = threading.Thread(target=self.proxy.serve_forever)
 
     def run(self):

--- a/plugin.video.amazon-test/service.py
+++ b/plugin.video.amazon-test/service.py
@@ -1,25 +1,68 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 from __future__ import unicode_literals
 import xbmc
-from resources.lib.common import Settings
+import threading
 from resources.lib.logging import Log
 from resources.lib.configs import *
 
-if __name__ == '__main__':
-    _s = Settings()
-    monitor = xbmc.Monitor()
-    Log('Service: Start')
-    check_freq = 60
-    export_freq = 24 * 60 * 60
 
-    if _s.wl_export:
+class BackgroundService():
+    freqCheck = 60
+    freqExport = 86400  # 24 * 60 * 60 seconds
+    lastCheck = 0
+
+    def __init__(self):
+        from resources.lib.common import Settings
+        from resources.lib.proxy import ProxyTCPD
+        self._s = Settings()
+        self.lastExport = float(getConfig('last_wl_export', '0'))
+        self.proxy = ProxyTCPD(self._s)
+        self._s.set('proxyaddress', '127.0.0.1:{}'.format(self.proxy.port))
+        Log('Service: Proxy bound to {}'.format(self._s.get('proxyaddress')))
+        self.proxy_thread = threading.Thread(target=self.proxy.serve_forever)
+
+    def run(self):
+
+        def _start_servers():
+            self.proxy.server_activate()
+            self.proxy.timeout = 1
+            self.proxy_thread.start()
+            Log('Service: Proxy server started')
+
+        def _stop_servers():
+            self.proxy.server_close()
+            self.proxy.shutdown()
+            self.proxy_thread.join()
+            Log('Service: Proxy server stopped')
+
+        from time import time
+        monitor = xbmc.Monitor()
+
+        _start_servers()
+        Log('Service started')
+
         while not monitor.abortRequested():
-            import time
-            last_export = float(getConfig('last_wl_export', '0'))
-            cur_time = time.time()
-            if cur_time >= last_export + export_freq:
-                Log('Service: Starting Export of Watchlist')
-                writeConfig('last_wl_export', cur_time)
-                xbmc.executebuiltin('XBMC.RunPlugin(plugin://plugin.video.amazon-test/?mode=getListMenu&url=watchlist&export=2)')
-            if monitor.waitForAbort(check_freq):
+            ct = time()
+            if (ct >= (self.lastCheck + self.freqCheck)) and self._s.wl_export:
+                self.lastCheck = ct
+                export_watchlist(ct)
+
+            if monitor.waitForAbort(1):
                 break
-    Log('Service: End')
+
+        _stop_servers()
+        Log('Service stopped')
+
+    def export_watchlist(self, cur_time=0, override=False):
+        """ Export the watchlist every self.freqExport seconds or when triggered by override """
+        if override or (cur_time >= (self.freqExport + self.lastExport)):
+            Log('Service: Exporting the Watchlist')
+            self.lastExport = cur_time
+            writeConfig('last_wl_export', cur_time)
+            xbmc.executebuiltin('XBMC.RunPlugin(plugin://plugin.video.amazon-test/?mode=getListMenu&url=watchlist&export=2)')
+
+
+if __name__ == '__main__':
+    BackgroundService().run()


### PR DESCRIPTION
Fixes #262
Fixes #264
Fixes #265

Introduces an HTTP only proxy service to be used with the Addon. Current features include language remapping for audio streams in MPDs and on-the-fly subtitle alteration (TTMLv2 => SRT). With this method we also don't need to pre-download subtitles anymore.

To fix some of the language selection problems, I also suppressed locale information when only one language code is available, for example:
* `es-es` and `es-419` are available, the former becomes `es`, the latter `es-Latinoamerica`
* `es-419` is available, becomes `es`

After the suggestion of @Paco8 I also introduced an option that provides a time stretched variant (slightly slower) of the subtitles, to fix some of the sync problems with the Spanish ones.