### PR TITLE
Missing tvShow.nfo

### DIFF
--- a/plugin.video.amazon-test/resources/lib/amazontld.py
+++ b/plugin.video.amazon-test/resources/lib/amazontld.py
@@ -334,6 +334,24 @@ class AmazonTLD(Singleton):
                 addDir(title, mode, url, info, opt)
         xbmcplugin.endOfDirectory(self._g.pluginhandle)
 
+    def exportTVShowNFO(self, infoLabels):
+        title = infoLabels['TVShowTitle']
+        filename = re.sub(r'(?i)\[.*| omu| ov', '', title).strip()
+        ExportPath = os.path.join(self._s.TV_SHOWS_PATH, self._cleanName(filename))
+        if not xbmcvfs.exists(os.path.join(ExportPath, 'tvshow.nfo')):
+
+            tvShowInfo = '<?xml version="1.0" encoding="UTF-8"?>\n'
+            tvShowInfo +='<tvshow>\n'
+            tvShowInfo +='<mpaa>%s</mpaa>\n' % infoLabels['MPAA']
+            tvShowInfo +='<plot>%s</plot>\n' % infoLabels['Plot']
+            tvShowInfo +='<showtitle>%s</showtitle>\n' % infoLabels['TVShowTitle']
+            tvShowInfo +='<title>%s</title>\n' % infoLabels['TVShowTitle']
+            tvShowInfo +='<thumb aspect="poster">%s</thumb>\n' % infoLabels['Thumb']
+            tvShowInfo +='<fanart><thumb>%s</thumb></fanart>\n' % infoLabels['Fanart'] 
+            tvShowInfo +='</tvshow>'
+            self.SaveFile('tvshow.nfo', tvShowInfo, ExportPath);
+            Log('Exported TVSeries: ' + ExportPath)
+            
     def listContent(self, catalog, url, page, parent, export=False):
         oldurl = url
         ResPage = 240 if export else self._s.MaxResults
@@ -400,6 +418,8 @@ class AmazonTLD(Singleton):
                             self._g.pluginid, quote_plus(curl))))
 
                 if export:
+                if self._g.addon.getSetting('cr_nfo') == 'true':
+                        self.exportTVShowNFO(infoLabels)
                     url = re.sub(r'(?i)contenttype=\w+', 'ContentType=TVEpisode', url)
                     url = re.sub(r'(?i)&rollupto\w+=\w+', '', url)
                     self.listContent('Browse', url, 1, parent.replace('_show', ''), export)

--- a/plugin.video.amazon-test/resources/lib/amazontld.py
+++ b/plugin.video.amazon-test/resources/lib/amazontld.py
@@ -338,19 +338,18 @@ class AmazonTLD(Singleton):
         title = infoLabels['TVShowTitle']
         filename = re.sub(r'(?i)\[.*| omu| ov', '', title).strip()
         ExportPath = os.path.join(self._s.TV_SHOWS_PATH, self._cleanName(filename))
-        if not xbmcvfs.exists(os.path.join(ExportPath, 'tvshow.nfo')):
-
-            tvShowInfo = '<?xml version="1.0" encoding="UTF-8"?>\n'
-            tvShowInfo +='<tvshow>\n'
-            tvShowInfo +='<mpaa>%s</mpaa>\n' % infoLabels['MPAA']
-            tvShowInfo +='<plot>%s</plot>\n' % infoLabels['Plot']
-            tvShowInfo +='<showtitle>%s</showtitle>\n' % infoLabels['TVShowTitle']
-            tvShowInfo +='<title>%s</title>\n' % infoLabels['TVShowTitle']
-            tvShowInfo +='<thumb aspect="poster">%s</thumb>\n' % infoLabels['Thumb']
-            tvShowInfo +='<fanart><thumb>%s</thumb></fanart>\n' % infoLabels['Fanart'] 
-            tvShowInfo +='</tvshow>'
-            self.SaveFile('tvshow.nfo', tvShowInfo, ExportPath);
-            Log('Exported TVSeries: ' + ExportPath)
+        #TODO: save tvShow.nfo only if it has changed
+        tvShowInfo = '<?xml version="1.0" encoding="UTF-8"?>\n'
+        tvShowInfo +='<tvshow>\n'
+        tvShowInfo +='<mpaa>%s</mpaa>\n' % infoLabels['MPAA']
+        tvShowInfo +='<plot>%s</plot>\n' % infoLabels['Plot']
+        tvShowInfo +='<showtitle>%s</showtitle>\n' % infoLabels['TVShowTitle']
+        tvShowInfo +='<title>%s</title>\n' % infoLabels['TVShowTitle']
+        tvShowInfo +='<thumb aspect="poster">%s</thumb>\n' % infoLabels['Thumb']
+        tvShowInfo +='<fanart><thumb>%s</thumb></fanart>\n' % infoLabels['Fanart'] 
+        tvShowInfo +='</tvshow>'
+        self.SaveFile('tvshow.nfo', tvShowInfo, ExportPath);
+        Log('Exported TVSeries: ' + ExportPath)
             
     def listContent(self, catalog, url, page, parent, export=False):
         oldurl = url


### PR DESCRIPTION
When exporting NFO files for TV Shows, Kodi requires a tvShow.nfo for the whole series, otherwise the show will not be visible in the library