### PR TITLE
Remove redundant check if inputstream.adaptive is installed.

### DIFF
--- a/plugin.video.amazon-test/resources/lib/playback.py
+++ b/plugin.video.amazon-test/resources/lib/playback.py
@@ -344,15 +344,6 @@ def PlayVideo(name, asin, adultstr, streamtype, forcefb=0):
         mpaa_str = AgeRestrictions().GetRestrictedAges() + getString(30171)
         drm_check = g.addon.getSetting("drm_check") == 'true'
 
-        verifyISA = '{"jsonrpc":"2.0","id":1,"method":"Addons.GetAddonDetails","params":{"addonid":"inputstream.adaptive"}}'
-        if 'error' in xbmc.executeJSONRPC(verifyISA):
-            xbmc.executebuiltin('UpdateAddonRepos', True)
-            xbmc.executebuiltin('InstallAddon(inputstream.adaptive)', True)
-            if 'error' in xbmc.executeJSONRPC(verifyISA):
-                Log('InputStream.Adaptive addon is not installed')
-                _playDummyVid()
-                return True
-
         inputstream_helper = Helper('mpd', drm='com.widevine.alpha')
 
         if not inputstream_helper.check_inputstream():

--- a/plugin.video.amazon/resources/lib/play.py
+++ b/plugin.video.amazon/resources/lib/play.py
@@ -173,14 +173,6 @@ def check_output(*popenargs, **kwargs):
 
 def IStreamPlayback(trailer, isAdult, extern):
     drm_check = var.addon.getSetting("drm_check") == 'true'
-    verifyISA = '{"jsonrpc":"2.0","id":1,"method":"Addons.GetAddonDetails","params":{"addonid":"inputstream.adaptive"}}'
-    if 'error' in xbmc.executeJSONRPC(verifyISA):
-        xbmc.executebuiltin('UpdateAddonRepos', True)
-        xbmc.executebuiltin('InstallAddon(inputstream.adaptive)', True)
-        if 'error' in xbmc.executeJSONRPC(verifyISA):
-            Log('InputStream.Adaptive addon is not installed')
-            playDummyVid()
-            return True
     inputstream_helper = Helper('mpd', drm='com.widevine.alpha')
     vMT = 'Trailer' if trailer else 'Feature'
 


### PR DESCRIPTION
Hi,
in the kodinerds thread, a user had problems playing movies, because inputstream.adaptive was not installed on his system (Ubuntu). I wondered why inputstreamhelper didn't show a message, as it should, and it seems that inputstreamhelper never gets executed if inputstream.adaptive is not installed.

Inputstreamhelper checks if inputstream.adaptive is installed, tries to install it and tells the user if not possible, so I think it's best to remove this functionality from these two addons.