### PR TITLE
Add about tag to config.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,5 +2,7 @@ blank_issues_enabled: false
 contact_links:
   - name: English Support Forum @ kodi.tv
     url: https://forum.kodi.tv/showthread.php?tid=349255
+    about: For questions in English use kodi.tv Forum.
   - name: German Support Forum @ kodinerds.net
     url: https://www.kodinerds.net/index.php/Thread/44211-Release-Amazon-Prime-Instant-Video/
+    about: For questions in German use kodinerds.net Forum.


### PR DESCRIPTION
config.yml not is working as excepted due missing "about" tag.

See screenshot after the change

![Captura de pantalla de 2020-05-08 21-06-28](https://user-images.githubusercontent.com/6617155/81441319-dd65f500-9171-11ea-9c80-e40672aa33cd.png)

Maybe the text of German Forum should be in German?
