### PR TITLE
Fix inputstreamaddon Kodi 19 incompatibility

### DIFF
--- a/plugin.video.amazon-test/resources/lib/playback.py
+++ b/plugin.video.amazon-test/resources/lib/playback.py
@@ -387,7 +387,11 @@ def PlayVideo(name, asin, adultstr, streamtype, forcefb=0):
         listitem.setProperty('%s.license_type' % g.is_addon, 'com.widevine.alpha')
         listitem.setProperty('%s.license_key' % g.is_addon, licURL)
         listitem.setProperty('%s.stream_headers' % g.is_addon, 'user-agent=' + getConfig('UserAgent'))
-        listitem.setProperty('inputstreamaddon', g.is_addon)
+        if int(xbmc.getInfoLabel('System.BuildVersion').split('.')[0]) >= 19:
+            listitem.setProperty('inputstream', g.is_addon)
+        else:
+            listitem.setProperty('inputstreamaddon', g.is_addon)
+
         listitem.setMimeType('application/dash+xml')
         listitem.setContentLookup(False)
         player = _AmazonPlayer()

--- a/plugin.video.amazon-test/resources/lib/playback.py
+++ b/plugin.video.amazon-test/resources/lib/playback.py
@@ -387,11 +387,8 @@ def PlayVideo(name, asin, adultstr, streamtype, forcefb=0):
         listitem.setProperty('%s.license_type' % g.is_addon, 'com.widevine.alpha')
         listitem.setProperty('%s.license_key' % g.is_addon, licURL)
         listitem.setProperty('%s.stream_headers' % g.is_addon, 'user-agent=' + getConfig('UserAgent'))
-        if int(xbmc.getInfoLabel('System.BuildVersion').split('.')[0]) >= 19:
-            listitem.setProperty('inputstream', g.is_addon)
-        else:
-            listitem.setProperty('inputstreamaddon', g.is_addon)
-
+        listitem.setProperty('inputstream', g.is_addon)
+        listitem.setProperty('inputstreamaddon', g.is_addon)
         listitem.setMimeType('application/dash+xml')
         listitem.setContentLookup(False)
         player = _AmazonPlayer()


### PR DESCRIPTION
I didn't test it, but I think this should fix the problem with 'inputstreamaddon' being deprecated in Kodi 19. See https://github.com/xbmc/xbmc/pull/18002