### PR TITLE
Episode list of TV Series with more than 25 episodes will show just 25 episodes

### DIFF
--- a/plugin.video.amazon-test/resources/lib/network.py
+++ b/plugin.video.amazon-test/resources/lib/network.py
@@ -767,6 +767,8 @@ def GrabJSON(url, bRaw=False):
             del qs['from']
         np = np._replace(path='/gp/video/api' + np.path, query=urlencode([(k, v) for k, l in qs.items() for v in l]))
         url = np.geturl()
+    if url.startswith('/detail/'):
+       url += ('&' if '?' in url else '?') + 'episodeListSize=9999'    
 
     r = getURL(FQify(url), silent=True, useCookie=True, rjson=False)
     if not r:


### PR DESCRIPTION
As reported in issue #482 only first 25 episodes will appear in list, adding episodeListSize=9999 to url all episodes apper in list @Varstahl 