### PR TITLE
Added setting to configure catalog cache expiration time

### DIFF
--- a/plugin.video.amazon-test/resources/language/resource.language.de_de/strings.po
+++ b/plugin.video.amazon-test/resources/language/resource.language.de_de/strings.po
@@ -673,3 +673,7 @@ msgstr "Bitte von GitHub herunterladen und in den Addon Ordner entpacken"
 msgctxt "#30256"
 msgid "Error: servers returned no content (check logs for more information)"
 msgstr "Fehler: Keine Inhalte vom Server erhalten (für mehr Infos Logs überprüfen)"
+
+msgctxt "#30257"
+msgid "Catalog cache expiration time"
+msgstr ""

--- a/plugin.video.amazon-test/resources/language/resource.language.de_de/strings.po
+++ b/plugin.video.amazon-test/resources/language/resource.language.de_de/strings.po
@@ -677,3 +677,35 @@ msgstr "Fehler: Keine Inhalte vom Server erhalten (für mehr Infos Logs überpr�
 msgctxt "#30257"
 msgid "Catalog cache expiration time"
 msgstr ""
+
+msgctxt "#30258"
+msgid "1 hour"
+msgstr ""
+
+msgctxt "#30259"
+msgid "6 hours"
+msgstr ""
+
+msgctxt "#30260"
+msgid "12 hours"
+msgstr ""
+
+msgctxt "#30261"
+msgid "1 day"
+msgstr ""
+
+msgctxt "#30262"
+msgid "3 days"
+msgstr ""
+
+msgctxt "#30263"
+msgid "7 days"
+msgstr ""
+
+msgctxt "#30264"
+msgid "15 days"
+msgstr ""
+
+msgctxt "#30265"
+msgid "30 days"
+msgstr ""

--- a/plugin.video.amazon-test/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.amazon-test/resources/language/resource.language.en_gb/strings.po
@@ -690,3 +690,35 @@ msgstr ""
 msgctxt "#30257"
 msgid "Catalog cache expiration time"
 msgstr ""
+
+msgctxt "#30258"
+msgid "1 hour"
+msgstr ""
+
+msgctxt "#30259"
+msgid "6 hours"
+msgstr ""
+
+msgctxt "#30260"
+msgid "12 hours"
+msgstr ""
+
+msgctxt "#30261"
+msgid "1 day"
+msgstr ""
+
+msgctxt "#30262"
+msgid "3 days"
+msgstr ""
+
+msgctxt "#30263"
+msgid "7 days"
+msgstr ""
+
+msgctxt "#30264"
+msgid "15 days"
+msgstr ""
+
+msgctxt "#30265"
+msgid "30 days"
+msgstr ""

--- a/plugin.video.amazon-test/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.amazon-test/resources/language/resource.language.en_gb/strings.po
@@ -686,3 +686,7 @@ msgstr ""
 msgctxt "#30256"
 msgid "Error: servers returned no content (check logs for more information)"
 msgstr ""
+
+msgctxt "#30257"
+msgid "Catalog cache expiration time"
+msgstr ""

--- a/plugin.video.amazon-test/resources/language/resource.language.es_es/strings.po
+++ b/plugin.video.amazon-test/resources/language/resource.language.es_es/strings.po
@@ -698,3 +698,7 @@ msgstr "Por favor, descárgalo de GitHub e instálalo manualmente en el director
 msgctxt "#30256"
 msgid "Error: servers returned no content (check logs for more information)"
 msgstr "Error: los servidores no han enviado ningún contenido (comprueba los registros para más información)"
+
+msgctxt "#30257"
+msgid "Catalog cache expiration time"
+msgstr ""

--- a/plugin.video.amazon-test/resources/language/resource.language.es_es/strings.po
+++ b/plugin.video.amazon-test/resources/language/resource.language.es_es/strings.po
@@ -702,3 +702,35 @@ msgstr "Error: los servidores no han enviado ningún contenido (comprueba los re
 msgctxt "#30257"
 msgid "Catalog cache expiration time"
 msgstr ""
+
+msgctxt "#30258"
+msgid "1 hour"
+msgstr ""
+
+msgctxt "#30259"
+msgid "6 hours"
+msgstr ""
+
+msgctxt "#30260"
+msgid "12 hours"
+msgstr ""
+
+msgctxt "#30261"
+msgid "1 day"
+msgstr ""
+
+msgctxt "#30262"
+msgid "3 days"
+msgstr ""
+
+msgctxt "#30263"
+msgid "7 days"
+msgstr ""
+
+msgctxt "#30264"
+msgid "15 days"
+msgstr ""
+
+msgctxt "#30265"
+msgid "30 days"
+msgstr ""

--- a/plugin.video.amazon-test/resources/language/resource.language.fr_ca/strings.po
+++ b/plugin.video.amazon-test/resources/language/resource.language.fr_ca/strings.po
@@ -700,3 +700,7 @@ msgstr "Veuillez le télécharger depuis GitHub et l'installer manuellement dans
 msgctxt "#30256"
 msgid "Error: servers returned no content (check logs for more information)"
 msgstr "Erreur: les serveurs n'ont renvoyé aucun contenu (consultez les journaux pour plus d'informations)"
+
+msgctxt "#30257"
+msgid "Catalog cache expiration time"
+msgstr ""

--- a/plugin.video.amazon-test/resources/language/resource.language.fr_ca/strings.po
+++ b/plugin.video.amazon-test/resources/language/resource.language.fr_ca/strings.po
@@ -704,3 +704,35 @@ msgstr "Erreur: les serveurs n'ont renvoyé aucun contenu (consultez les journau
 msgctxt "#30257"
 msgid "Catalog cache expiration time"
 msgstr ""
+
+msgctxt "#30258"
+msgid "1 hour"
+msgstr ""
+
+msgctxt "#30259"
+msgid "6 hours"
+msgstr ""
+
+msgctxt "#30260"
+msgid "12 hours"
+msgstr ""
+
+msgctxt "#30261"
+msgid "1 day"
+msgstr ""
+
+msgctxt "#30262"
+msgid "3 days"
+msgstr ""
+
+msgctxt "#30263"
+msgid "7 days"
+msgstr ""
+
+msgctxt "#30264"
+msgid "15 days"
+msgstr ""
+
+msgctxt "#30265"
+msgid "30 days"
+msgstr ""

--- a/plugin.video.amazon-test/resources/language/resource.language.he_il/strings.po
+++ b/plugin.video.amazon-test/resources/language/resource.language.he_il/strings.po
@@ -713,3 +713,35 @@ msgstr ""
 msgctxt "#30257"
 msgid "Catalog cache expiration time"
 msgstr ""
+
+msgctxt "#30258"
+msgid "1 hour"
+msgstr ""
+
+msgctxt "#30259"
+msgid "6 hours"
+msgstr ""
+
+msgctxt "#30260"
+msgid "12 hours"
+msgstr ""
+
+msgctxt "#30261"
+msgid "1 day"
+msgstr ""
+
+msgctxt "#30262"
+msgid "3 days"
+msgstr ""
+
+msgctxt "#30263"
+msgid "7 days"
+msgstr ""
+
+msgctxt "#30264"
+msgid "15 days"
+msgstr ""
+
+msgctxt "#30265"
+msgid "30 days"
+msgstr ""

--- a/plugin.video.amazon-test/resources/language/resource.language.he_il/strings.po
+++ b/plugin.video.amazon-test/resources/language/resource.language.he_il/strings.po
@@ -709,3 +709,7 @@ msgstr ""
 msgctxt "#30256"
 msgid "Error: servers returned no content (check logs for more information)"
 msgstr ""
+
+msgctxt "#30257"
+msgid "Catalog cache expiration time"
+msgstr ""

--- a/plugin.video.amazon-test/resources/language/resource.language.it_it/strings.po
+++ b/plugin.video.amazon-test/resources/language/resource.language.it_it/strings.po
@@ -700,3 +700,35 @@ msgstr "Errore: nessun contenuto fornito dai server (controllare i log per maggi
 msgctxt "#30257"
 msgid "Catalog cache expiration time"
 msgstr ""
+
+msgctxt "#30258"
+msgid "1 hour"
+msgstr ""
+
+msgctxt "#30259"
+msgid "6 hours"
+msgstr ""
+
+msgctxt "#30260"
+msgid "12 hours"
+msgstr ""
+
+msgctxt "#30261"
+msgid "1 day"
+msgstr ""
+
+msgctxt "#30262"
+msgid "3 days"
+msgstr ""
+
+msgctxt "#30263"
+msgid "7 days"
+msgstr ""
+
+msgctxt "#30264"
+msgid "15 days"
+msgstr ""
+
+msgctxt "#30265"
+msgid "30 days"
+msgstr ""

--- a/plugin.video.amazon-test/resources/language/resource.language.it_it/strings.po
+++ b/plugin.video.amazon-test/resources/language/resource.language.it_it/strings.po
@@ -696,3 +696,7 @@ msgstr "Scaricalo da GitHub e installalo manualmente nella directory dell'addon"
 msgctxt "#30256"
 msgid "Error: servers returned no content (check logs for more information)"
 msgstr "Errore: nessun contenuto fornito dai server (controllare i log per maggiori informazioni)"
+
+msgctxt "#30257"
+msgid "Catalog cache expiration time"
+msgstr ""

--- a/plugin.video.amazon-test/resources/language/resource.language.pl_pl/strings.po
+++ b/plugin.video.amazon-test/resources/language/resource.language.pl_pl/strings.po
@@ -685,3 +685,35 @@ msgstr ""
 msgctxt "#30257"
 msgid "Catalog cache expiration time"
 msgstr ""
+
+msgctxt "#30258"
+msgid "1 hour"
+msgstr ""
+
+msgctxt "#30259"
+msgid "6 hours"
+msgstr ""
+
+msgctxt "#30260"
+msgid "12 hours"
+msgstr ""
+
+msgctxt "#30261"
+msgid "1 day"
+msgstr ""
+
+msgctxt "#30262"
+msgid "3 days"
+msgstr ""
+
+msgctxt "#30263"
+msgid "7 days"
+msgstr ""
+
+msgctxt "#30264"
+msgid "15 days"
+msgstr ""
+
+msgctxt "#30265"
+msgid "30 days"
+msgstr ""

--- a/plugin.video.amazon-test/resources/language/resource.language.pl_pl/strings.po
+++ b/plugin.video.amazon-test/resources/language/resource.language.pl_pl/strings.po
@@ -681,3 +681,7 @@ msgstr ""
 msgctxt "#30256"
 msgid "Error: servers returned no content (check logs for more information)"
 msgstr ""
+
+msgctxt "#30257"
+msgid "Catalog cache expiration time"
+msgstr ""

--- a/plugin.video.amazon-test/resources/lib/common.py
+++ b/plugin.video.amazon-test/resources/lib/common.py
@@ -199,6 +199,8 @@ class Settings(Singleton):
             'collections': self._gs('paginate_collections') == 'true',
             'search': self._gs('paginate_search') == 'true'
         }
+        elif 'catalogCacheExpiry' == name: 
+            return [3600, 21600, 43200, 86400, 259200, 604800, 1296000, 2592000][int(self._gs('catalog_cache_expiry'))]            
 
 
 def jsonRPC(method, props='', param=None):

--- a/plugin.video.amazon-test/resources/lib/primevideo.py
+++ b/plugin.video.amazon-test/resources/lib/primevideo.py
@@ -283,8 +283,8 @@ class PrimeVideo(Singleton):
         except:
             Log('Search functionality not found', Log.ERROR)
 
-        # Set the expiration in 11 hours and flush to disk
-        self._catalog['expiration'] = 39600 + int(time.time())
+        # Set the expiration based on settings (defaults to 12 hours) and flush to disk
+        self._catalog['expiration'] = self._s.catalogCacheExpiry + int(time.time())
         self._Flush()
 
         return True

--- a/plugin.video.amazon-test/resources/settings.xml
+++ b/plugin.video.amazon-test/resources/settings.xml
@@ -107,7 +107,7 @@
     <!-- PrimeVideo -->
     <category label="30250">
         <setting id="pv_episode_thumbnails" type="bool" label="30249" default="true"/>
-        <setting id="catalog_cache_expiry" type="enum" values="1 hour|6 hours|12 hours|1 day|3 days|7 days|15 days|30 days" label="30257" default="2"/>
+        <setting id="catalog_cache_expiry" type="enum" lvalues="30258|30259|30260|30261|30262|30263|30264|30265" label="30257" default="2"/>
         <setting label="30243" type="lsep"/>
         <setting id="paginate_everything" type="bool" label="30244" default="false"/>
         <setting id="paginate_watchlist" type="bool" label="30245" default="false" enable="eq(-1,false)"/>

--- a/plugin.video.amazon-test/resources/settings.xml
+++ b/plugin.video.amazon-test/resources/settings.xml
@@ -107,6 +107,7 @@
     <!-- PrimeVideo -->
     <category label="30250">
         <setting id="pv_episode_thumbnails" type="bool" label="30249" default="true"/>
+        <setting id="catalog_cache_expiry" type="enum" values="1 hour|6 hours|12 hours|1 day|3 days|7 days|15 days|30 days" label="30257" default="2"/>
         <setting label="30243" type="lsep"/>
         <setting id="paginate_everything" type="bool" label="30244" default="false"/>
         <setting id="paginate_watchlist" type="bool" label="30245" default="false" enable="eq(-1,false)"/>


### PR DESCRIPTION
Fixes #499

Supports cache expiry times of 1 hour, 6 hours, 12 hours, 1 day, 3 days, 7 days, 15 days, 30 days with default as 12 hours. Can configure in Settings -> Prime video.

Please let me know if you want me to add other language strings using Google translate. I can only speak English natively.
Also, any changes required in cache options? Should I add an option to disable cache also (Expiry time: 0 seconds)? 

I have tested in Raspberry Pi 3 on OSMC and it seems to work fine.