### PR TITLE
bump python version

### DIFF
--- a/script.module.mechanicalsoup/addon.xml
+++ b/script.module.mechanicalsoup/addon.xml
@@ -4,7 +4,7 @@
 	version="1.0.0"
 	provider-name="Matthew Hickford, Dan Hemberger, Matthieu Moy">
 	<requires>
-		<import addon="xbmc.python" version="2.25.0"/>
+		<import addon="xbmc.python" version="3.0.0"/>
 		<import addon="script.module.requests" version="2.0.0"/>
 		<import addon="script.module.beautifulsoup4" version="4.4.0"/>
 		<import addon="script.module.six" version="1.4.0"/>


### PR DESCRIPTION
in order to be able to install mechanicalsoup on Kodi 19+,
bump dependency to 3.0.0