### PR TITLE
Lower minimum TLS version on Python 3.7 and higher for signing in.

### DIFF
--- a/plugin.video.amazon-test/resources/lib/network.py
+++ b/plugin.video.amazon-test/resources/lib/network.py
@@ -1028,7 +1028,7 @@ class MyTLS1Adapter(HTTPAdapter):
         Log('TLSv1 Adapter', Log.DEBUG)
         if ssl.OPENSSL_VERSION_INFO[:4] >= (1, 1, 1, 6):  # openssl 1.1.1f
             context = ssl.create_default_context()
-            if sys.version_info.major >= 3 and sys.version_info.minor >= 7:
+            if sys.version_info >= (3, 7):
                 context.minimum_version = ssl.TLSVersion.TLSv1
             context.set_ciphers('DEFAULT@SECLEVEL=1')
             kwargs['ssl_context'] = context

--- a/plugin.video.amazon-test/resources/lib/network.py
+++ b/plugin.video.amazon-test/resources/lib/network.py
@@ -11,6 +11,7 @@ import pyxbmct
 import re
 import requests
 import ssl
+import sys
 from timeit import default_timer as timer
 from urllib3.poolmanager import PoolManager
 from requests.adapters import HTTPAdapter
@@ -1026,6 +1027,8 @@ class MyTLS1Adapter(HTTPAdapter):
         Log('TLSv1 Adapter', Log.DEBUG)
         if ssl.OPENSSL_VERSION_INFO[:4] >= (1, 1, 1, 6):  # openssl 1.1.1f
             context = ssl.create_default_context()
+            if sys.version_info.major >= 3 and sys.version_info.minor >= 7:
+                context.minimum_version = ssl.TLSVersion.TLSv1
             context.set_ciphers('DEFAULT@SECLEVEL=1')
             kwargs['ssl_context'] = context
         self.poolmanager = PoolManager(num_pools=connections, maxsize=maxsize, block=block, ssl_version=ssl.PROTOCOL_TLSv1, *args, **kwargs)

--- a/plugin.video.amazon-test/resources/lib/network.py
+++ b/plugin.video.amazon-test/resources/lib/network.py
@@ -12,6 +12,7 @@ import re
 import requests
 import ssl
 import sys
+
 from timeit import default_timer as timer
 from urllib3.poolmanager import PoolManager
 from requests.adapters import HTTPAdapter


### PR DESCRIPTION
I ran in the same problem as mentioned here: https://github.com/Sandmann79/xbmc/issues/540#issuecomment-772531015

A partial solution/workaround was provided in the next comment (installing a compat package), but that didn't work on my system (Gentoo Linux).

It seems that Python removed the default "accept all SSL/TLS versions" (through SSLContext.options) in version 3.7 and introduced SSLContext.minimum_version, which is set to TLSVersion.TLSv1_2 by default on my system.

The PR contains a check on the python version and sets SSLContext.minimum_version to the version as suggested in the link above. The compat package should not be required anymore to make this work.