### PR TITLE
Use cookie auth if requesting the manifest fails with token auth

### DIFF
--- a/plugin.video.amazon-test/resources/lib/playback.py
+++ b/plugin.video.amazon-test/resources/lib/playback.py
@@ -321,8 +321,8 @@ def PlayVideo(name, asin, adultstr, streamtype, forcefb=0):
         # If not, then the second iteration will fall back to cookie authentification
         # and try again. This is neccessary for content like Amazon Freevee, which is not
         # available though token based authentification.
-        for t in [True, False]:
-            cookie, opt_lic, headers, dtid = _getPlaybackVars(preferToken=t)
+        for preferTokenToCookie in [True, False]:
+            cookie, opt_lic, headers, dtid = _getPlaybackVars(preferToken=preferTokenToCookie)
             if not cookie:
                 g.dialog.notification(getString(30203), getString(30200), xbmcgui.NOTIFICATION_ERROR)
                 Log('Login error at playback')
@@ -331,7 +331,7 @@ def PlayVideo(name, asin, adultstr, streamtype, forcefb=0):
                 writeConfig('uhdinfo', '1')
 
             success, data = getURLData('catalog/GetPlaybackResources', asin, extra=True, vMT=vMT, dRes=dRes, useCookie=cookie, devicetypeid=dtid,
-                                        proxyEndpoint=(None if bypassproxy else 'gpr'), opt=opt)
+                                       proxyEndpoint=(None if bypassproxy else 'gpr'), opt=opt)
 
             if success:
                 break


### PR DESCRIPTION
Some content, like Amazon Freevee, is not available when using token auth. By allowing to use cookie auth if token auth does not work, it will be possible to play that content without degrading the quality of anything that is available with token auth.

Admittedly, just stuffing the code into a loop that iterates over `[True, False]` is a bit of a hack, but it seemed cleaner that just putting the code there a second time. I would have prefered a method, but given that the return values from `_getPlaybackVars` are used later, this could have become a bit messy. In a loop they will just "leak" to the outside, because of python.