### PR TITLE
Allow Web API searching by path

### DIFF
--- a/plugin.video.amazon-test/resources/lib/web_api.py
+++ b/plugin.video.amazon-test/resources/lib/web_api.py
@@ -275,7 +275,7 @@ class PrimeVideo(Singleton):
                     }
 
     def Route(self, verb, path):
-        if 'search' == verb: g.pv.Search()
+        if 'search' == verb: g.pv.Search(path.get('searchstring'))
         elif 'browse' == verb: g.pv.Browse(path)
         elif 'refresh' == verb: g.pv.Refresh(path)
         elif 'profiles' == verb: g.pv.Profile(path)


### PR DESCRIPTION
This small change allows searches based on the Web API to be performed via a path call which includes the `searchstring` parameter.