### PR TITLE
Kodi 20 compability for browser launcher

### DIFF
--- a/plugin.program.browser.launcher/default.py
+++ b/plugin.program.browser.launcher/default.py
@@ -7,7 +7,10 @@ import subprocess
 import xbmcplugin
 import xbmcgui
 import xbmcaddon
-import xbmcvfs
+try:
+    from xbmcvfs import translatePath
+except ImportError:
+    from xbmc import translatePath
 try:
     from urllib.parse import unquote_plus, quote_plus
 except ImportError:
@@ -21,12 +24,12 @@ addonPath = addon.getAddonInfo('path')
 translation = addon.getLocalizedString
 useOwnProfile = addon.getSetting("useOwnProfile") == "true"
 useCustomPath = addon.getSetting("useCustomPath") == "true"
-customPath = xbmcvfs.translatePath(addon.getSetting("customPath"))
+customPath = translatePath(addon.getSetting("customPath"))
 winBrowser = int(addon.getSetting("winBrowser"))
 #prio_values = ['LOW', 'BELOWNORMAL', 'NORMAL', 'ABOVENORMAL', 'HIGH', 'REALTIME' ]
 prio_values = [ 0x00000040, 0x00004000, 0x00000020, 0x00008000, 0x00000080, 0x00000100 ]
 priority = prio_values[int(addon.getSetting("priority"))]
-userDataFolder = xbmcvfs.translatePath("special://profile/addon_data/"+addonID)
+userDataFolder = translatePath("special://profile/addon_data/"+addonID)
 profileFolder = os.path.join(userDataFolder, 'profile')
 siteFolder = os.path.join(userDataFolder, 'sites')
 avBrowsers = ['Standard', 'Internet Explorer', 'Kylo', 'Chrome', 'Firefox', 'Opera']

--- a/plugin.program.browser.launcher/default.py
+++ b/plugin.program.browser.launcher/default.py
@@ -7,6 +7,7 @@ import subprocess
 import xbmcplugin
 import xbmcgui
 import xbmcaddon
+import xbmcvfs
 try:
     from urllib.parse import unquote_plus, quote_plus
 except ImportError:
@@ -20,12 +21,12 @@ addonPath = addon.getAddonInfo('path')
 translation = addon.getLocalizedString
 useOwnProfile = addon.getSetting("useOwnProfile") == "true"
 useCustomPath = addon.getSetting("useCustomPath") == "true"
-customPath = xbmc.translatePath(addon.getSetting("customPath"))
+customPath = xbmcvfs.translatePath(addon.getSetting("customPath"))
 winBrowser = int(addon.getSetting("winBrowser"))
 #prio_values = ['LOW', 'BELOWNORMAL', 'NORMAL', 'ABOVENORMAL', 'HIGH', 'REALTIME' ]
 prio_values = [ 0x00000040, 0x00004000, 0x00000020, 0x00008000, 0x00000080, 0x00000100 ]
 priority = prio_values[int(addon.getSetting("priority"))]
-userDataFolder = xbmc.translatePath("special://profile/addon_data/"+addonID)
+userDataFolder = xbmcvfs.translatePath("special://profile/addon_data/"+addonID)
 profileFolder = os.path.join(userDataFolder, 'profile')
 siteFolder = os.path.join(userDataFolder, 'sites')
 avBrowsers = ['Standard', 'Internet Explorer', 'Kylo', 'Chrome', 'Firefox', 'Opera']


### PR DESCRIPTION
After Updating Kodi from 19 to 20 I received the following exception from plugin.program.browser.launcher:
```
EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                                    - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                                   Error Type: <class 'AttributeError'>
                                                   Error Contents: module 'xbmc' has no attribute 'translatePath'
                                                   Traceback (most recent call last):
                                                     File "/home/kodi/.kodi/addons/plugin.program.browser.launcher/default.py", line 23, in <module>
                                                       customPath = xbmc.translatePath(addon.getSetting("customPath"))
                                                   AttributeError: module 'xbmc' has no attribute 'translatePath'
                                                   -->End of Python script error report<--
```

The proposed changes fixes browser.launcher to work with Kodi 20.

Please have a look when time permits. Thank you!