### PR TITLE
Update playback.py

### DIFF
--- a/plugin.video.amazon-test/resources/lib/playback.py
+++ b/plugin.video.amazon-test/resources/lib/playback.py
@@ -445,7 +445,7 @@ def PlayVideo(name, asin, adultstr, streamtype, forcefb=0):
         return False
 
     isAdult = adultstr == '1'
-    amazonUrl = g.BaseUrl + "/dp/" + (name if g.UsePrimeVideo else asin)
+    amazonUrl = g.BaseUrl + "/dp/" + (name.decode("utf-8") if g.UsePrimeVideo else asin)
     videoUrl = "%s/?autoplay=%s" % (amazonUrl, ('trailer' if streamtype == 1 else '1'))
     extern = not xbmc.getInfoLabel('Container.PluginName').startswith('plugin.video.amazon')
     suc = False


### PR DESCRIPTION
Fix the error below when the language of Amazon Prime Video is French in the names.

Error: 

2023-01-29 01:41:26.537 T:2774847680   ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                             - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                            Error Type: <type 'exceptions.UnicodeDecodeError'>
                                            Error Contents: 'ascii' codec can't decode byte 0xc3 in position 4: ordinal not in range(128)
                                            Traceback (most recent call last):
                                              File "/home/pi/.kodi/addons/plugin.video.amazon-test/default.py", line 5, in <module>
                                                EntryPoint()
                                              File "/home/pi/.kodi/addons/plugin.video.amazon-test/resources/lib/startup.py", line 70, in EntryPoint
                                                PlayVideo(args.get('name', ''), args.get('asin'), args.get('adult', '0'), int(args.get('trailer', '0')), int(args.get('selbitrate', '0')))
                                              File "/home/pi/.kodi/addons/plugin.video.amazon-test/resources/lib/playback.py", line 437, in PlayVideo
                                                amazonUrl = g.BaseUrl + "/dp/" + (name.encode("utf-8") if g.UsePrimeVideo else asin)
                                            UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 4: ordinal not in range(128)
                                            -->End of Python script error report<--