### PR TITLE
Fix broken fetch of season fanart

### DIFF
--- a/plugin.video.amazon-test/resources/lib/android_api.py
+++ b/plugin.video.amazon-test/resources/lib/android_api.py
@@ -467,7 +467,7 @@ class PrimeVideo(Singleton):
                 asins = self.getAsins(content[0], False)
                 del content
 
-        if 'season' in contentType and il['season'] == 1:
+        if contentType == 'season' and season_number == 1:
             s_il = deepcopy(il)
             s_il['title'] = il['tvshowtitle']
             cur.execute('insert or ignore into art values (?,?,?,?)', (il['seriesasin'], -1, json.dumps(s_il), self.days_since_epoch()))


### PR DESCRIPTION
When fetching season fanart via `android_api`, the operation failed causing repeated error messages and logs:
```
2023-10-01 17:56:39.613 T:5987     info <general>: [Amazon VOD] Starting Fanart Update
2023-10-01 17:56:39.626 T:5987     info <general>: [Amazon VOD] getURL: https://atv-ps-eu.amazon.de/cdp/mobile/getDataByTransform/v1/android/atf/v3.jstl?deviceTypeID=A43PXU4ZN2AL1&firmware=fmw:22-app:3.0.351.3955&softwareVersion=351&priorityLevel=2&format=json&featureScheme=mobile-android-features-v11&deviceID=7b6356e9d478429f86124f2de6d84fbc&version=1&screenWidth=sw800dp&osLocale=de_DE&uxLocale=de_DE&supportsPKMZ=false&isLiveEventsV2OverrideEnabled=true&swiftPriorityLevel=critical&itemId=amzn1.dv.gti.9aaffebb-576e-d355-a2d4-9ed14731e7ab&capabilities=
2023-10-01 17:56:39.895 T:5987    error <general>: [Amazon VOD] Error reason: 500 error (TryAgain)
2023-10-01 17:56:39.896 T:5987     info <general>: [Amazon VOD] Switching UserAgent
2023-10-01 17:56:39.897 T:5987     info <general>: [Amazon VOD] Loading list of common UserAgents
2023-10-01 17:56:39.899 T:5987     info <general>: [Amazon VOD] getURL: http://www.skydubh.com/pub/useragents.json
2023-10-01 17:56:39.951 T:5987     info <general>: [Amazon VOD] Using UserAgent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:71.0) Gecko/20100101 Firefox/71.0
2023-10-01 17:56:39.952 T:5987     info <general>: [Amazon VOD] Attempt #2
2023-10-01 17:56:39.952 T:5987     info <general>: [Amazon VOD] getURL: https://atv-ps-eu.amazon.de/cdp/mobile/getDataByTransform/v1/android/atf/v3.jstl?deviceTypeID=A43PXU4ZN2AL1&firmware=fmw:22-app:3.0.351.3955&softwareVersion=351&priorityLevel=2&format=json&featureScheme=mobile-android-features-v11&deviceID=7b6356e9d478429f86124f2de6d84fbc&version=1&screenWidth=sw800dp&osLocale=de_DE&uxLocale=de_DE&supportsPKMZ=false&isLiveEventsV2OverrideEnabled=true&swiftPriorityLevel=critical&itemId=amzn1.dv.gti.9aaffebb-576e-d355-a2d4-9ed14731e7ab&capabilities=
2023-10-01 17:56:40.062 T:5987    error <general>: [Amazon VOD] Error reason: 500 error (TryAgain)
2023-10-01 17:56:40.063 T:5987     info <general>: [Amazon VOD] Switching UserAgent
2023-10-01 17:56:40.065 T:5987     info <general>: [Amazon VOD] Loading list of common UserAgents
2023-10-01 17:56:40.067 T:5987     info <general>: [Amazon VOD] getURL: http://www.skydubh.com/pub/useragents.json
2023-10-01 17:56:40.121 T:5987     info <general>: [Amazon VOD] Using UserAgent: Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko
2023-10-01 17:56:40.123 T:5987     info <general>: [Amazon VOD] Attempt #3
2023-10-01 17:56:40.125 T:5987     info <general>: [Amazon VOD] getURL: https://atv-ps-eu.amazon.de/cdp/mobile/getDataByTransform/v1/android/atf/v3.jstl?deviceTypeID=A43PXU4ZN2AL1&firmware=fmw:22-app:3.0.351.3955&softwareVersion=351&priorityLevel=2&format=json&featureScheme=mobile-android-features-v11&deviceID=7b6356e9d478429f86124f2de6d84fbc&version=1&screenWidth=sw800dp&osLocale=de_DE&uxLocale=de_DE&supportsPKMZ=false&isLiveEventsV2OverrideEnabled=true&swiftPriorityLevel=critical&itemId=amzn1.dv.gti.9aaffebb-576e-d355-a2d4-9ed14731e7ab&capabilities=
2023-10-01 17:56:40.226 T:5987    error <general>: [Amazon VOD] Error reason: 500 error (TryAgain)
2023-10-01 17:56:40.231 T:5987    error <general>: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                                    - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                                   Error Type: <class 'KeyError'>
                                                   Error Contents: 'season'
                                                   Traceback (most recent call last):
                                                     File "/storage/.kodi/addons/plugin.video.amazon-test/default.py", line 7, in <module>
                                                       EntryPoint()
                                                     File "/storage/.kodi/addons/plugin.video.amazon-test/resources/lib/startup.py", line 95, in EntryPoint
                                                       _g.pv.Route(mode, args)
                                                     File "/storage/.kodi/addons/plugin.video.amazon-test/resources/lib/android_api.py", line 670, in Route
                                                       exec ('self._g.pv.{}()'.format(mode))
                                                     File "<string>", line 1, in <module>
                                                     File "/storage/.kodi/addons/plugin.video.amazon-test/resources/lib/android_api.py", line 418, in processMissing
                                                       self.retrieveArtWork(*data)
                                                     File "/storage/.kodi/addons/plugin.video.amazon-test/resources/lib/android_api.py", line 467, in retrieveArtWork
                                                       if 'season' in contentType and il['season'] == 1:
                                                                                      ~~^^^^^^^^^^
                                                   KeyError: 'season'
                                                   -->End of Python script error report<--
```
I was able to fix this by using the previously evaluated `season_number`, instead of using `season` as index for `dict il`.

Affected versions are: 0.9.9..1.0.0