### PR TITLE
Fix for changed navigation structure

### DIFF
--- a/plugin.video.amazon-test/resources/lib/network.py
+++ b/plugin.video.amazon-test/resources/lib/network.py
@@ -486,7 +486,9 @@ def GrabJSON(url, postData=None):
                 if 'body' in m and len(m['body']) > 0:
                     body = m['body'][0]
                     if 'siteWide' in m and 'bodyStart' in m['siteWide'] and len(m['siteWide']['bodyStart']) > 0:
-                        m = m['siteWide']['bodyStart'][0]['props']
+                        for bs in m['siteWide']['bodyStart']:
+                            if 'name' in bs and bs['name'] == 'navigation-bar' and 'props' in bs:
+                                m = bs['props']                        
                     if 'props' in body:
                         body = body['props']
                         for p in ['atf', 'btf', 'landingPage', 'browse', 'search', 'categories', 'genre']:


### PR DESCRIPTION
If fixed this on my kodi installation by iterating over siteWide->bodyStart and pick the one with name navigation-bar instead of always the first.

Please kindly review and if it meets your standards merge this change to get this sorted out for other users of this addon.

fixes #749 , fixes #750 
