### PR TITLE
[playback] restore manifest_type property for version of Kodi prior to 21

### DIFF
--- a/plugin.video.amazon-test/resources/lib/playback.py
+++ b/plugin.video.amazon-test/resources/lib/playback.py
@@ -396,6 +396,8 @@ def PlayVideo(name, asin, adultstr, streamtype, forcefb=0):
         Log('Using %s Version: %s' % (_g.is_addon, is_version))
 
         listitem = xbmcgui.ListItem(label=title, path=mpd)
+        if (_g.KodiVersion < 21) and ('adaptive' in _g.is_addon):
+            listitem.setProperty('inputstream.adaptive.manifest_type', 'mpd')
         listitem.setArt({'thumb': thumb})
         listitem.setSubtitles(subs)
         listitem.setProperty('%s.license_type' % _g.is_addon, 'com.widevine.alpha')


### PR DESCRIPTION
This change addresses #753 for OSMC 2024.05-1 and Kodi 20.5 on Raspberry Pi 4.