### PR TITLE
Add webOS support

### DIFF
--- a/plugin.video.amazon-test/resources/lib/common.py
+++ b/plugin.video.amazon-test/resources/lib/common.py
@@ -43,6 +43,7 @@ class Globals(Singleton):
     OS_OSX = 4
     OS_ANDROID = 8
     OS_LE = 16
+    OS_WEBOS = 32
 
     is_addon = 'inputstream.adaptive'
     na = 'not available'
@@ -113,6 +114,8 @@ class Globals(Singleton):
             self._globals['platform'] |= self.OS_OSX
         if xbmc.getCondVisibility('system.platform.android'):
             self._globals['platform'] |= self.OS_ANDROID
+        if xbmc.getCondVisibility('system.platform.webos'):
+            self._globals['platform'] |= self.OS_WEBOS
         if (xbmcvfs.exists('/etc/os-release')) and ('libreelec' in xbmcvfs.File('/etc/os-release').read()):
             self._globals['platform'] |= self.OS_LE
 

--- a/plugin.video.amazon-test/resources/lib/network.py
+++ b/plugin.video.amazon-test/resources/lib/network.py
@@ -224,7 +224,7 @@ def getURLData(mode, asin, retformat='json', devicetypeid=_g.dtid_web, version=2
     url += '&version=' + str(version)
     url += '&gascEnabled=' + str(_g.UsePrimeVideo).lower()
     url += "&subtitleFormat=TTMLv2" if 'SubtitleUrls' in dRes else ''
-    url += '&operatingSystemName=Windows' if playback_req and (_g.platform & _g.OS_ANDROID) and devicetypeid == _g.dtid_web and _s.wvl1_device else ''  # cookie auth on android
+    url += '&operatingSystemName=Windows' if playback_req and (_g.platform & _g.OS_ANDROID or _g.platform & _g.OS_WEBOS) and devicetypeid == _g.dtid_web and _s.wvl1_device else ''  # cookie auth on android
     if extra:
         url += '&resourceUsage=ImmediateConsumption&consumptionType=Streaming&deviceDrmOverride=CENC' \
                '&deviceStreamingTechnologyOverride=DASH&deviceProtocolOverride=Https' \

--- a/plugin.video.amazon-test/resources/settings.xml
+++ b/plugin.video.amazon-test/resources/settings.xml
@@ -27,10 +27,10 @@
         <setting id="pref_host" type="labelenum" label="30019" visible="eq(-17,3)" values="Auto|Akamai|Cloudfront|Level3|Limelight" default="Auto"/>
         <setting id="is_settings" type="action" label="30013" visible="eq(-18,3)" action="RunPlugin(plugin://plugin.video.amazon-test/?mode=openSettings&url=is)" option="close"/>
         <setting id="age_settings" type="action" label="30018" visible="eq(-19,3)" action="RunPlugin(plugin://plugin.video.amazon-test/?mode=ageSettings)" option="close"/>
-        <setting id="wvl1_device" type="bool" label="30006" visible="eq(-20,3)" enable="System.Platform.Android" default="false"/>
-        <setting id="enable_uhd" type="bool" label="UltraHD / 4K" visible="eq(-21,3) + eq(-1,true)" default="false" subsetting="true"/>
-        <setting id="enable_hdr10" type="bool" label="HDR10+" visible="eq(-22,3) + eq(-2,true)" default="false" subsetting="true"/>
-        <setting id="enable_dovi" type="bool" label="Dolby Vision" visible="eq(-23,3) + eq(-3,true)" default="false" subsetting="true"/>
+        <setting id="wvl1_device" type="bool" label="30006" visible="eq(-20,3)" enable="System.Platform.Android|System.Platform.webOS" default="false"/>
+        <setting id="enable_uhd" type="bool" label="UltraHD / 4K" visible="eq(-21,3) + eq(-1,true)" enable="System.Platform.Android|System.Platform.webOS" default="false" subsetting="true"/>
+        <setting id="enable_hdr10" type="bool" label="HDR10+" visible="eq(-22,3) + eq(-2,true)" enable="System.Platform.Android|System.Platform.webOS" default="false" subsetting="true"/>
+        <setting id="enable_dovi" type="bool" label="Dolby Vision" visible="eq(-23,3) + eq(-3,true)" enable="System.Platform.Android|System.Platform.webOS" default="false" subsetting="true"/>
         <setting id="enable_atmos" type="bool" label="Dolby Atmos" visible="eq(-24,3) + eq(-4,true)" enable="eq(2,true)" default="false" subsetting="true"/>
         <setting id="use_h265" type="bool" label="30020" visible="eq(-25,3) + eq(-5,true)" default="false" subsetting="true"/>
         <setting id="proxy_mpdalter" type="bool" label="30248" default="true" visible="eq(-26,3)"/>


### PR DESCRIPTION
Widevine support for webOS was recently added: https://github.com/xbmc/inputstream.adaptive/pull/1893
Currently it only supports L1 without secure decoder, but this will be added in the near future: https://github.com/cscd98/inputstream.adaptive/commits/webos/

This PR adds webOS support. I tested multiple movies and series and HDR/DV is working with the changes from that branch. With the current inputstream.adaptive version 1080p playback without HDR is possible because it doesn't need secure decoder.