### PR TITLE
l10n: en_GB was missing some fields

### DIFF
--- a/plugin.video.amazon-test/resources/lib/l10n.py
+++ b/plugin.video.amazon-test/resources/lib/l10n.py
@@ -90,6 +90,7 @@ datetimeParser = {
         'iso6392': 'eng'
     },
     'en_GB': {
+        'language': 'English',
         'deconstruct': '^(?P<d>[0-9]+)\\.?\\s+(?P<m>[^\\s]+)\\s+(?P<y>[0-9]+)',
         'months': {
             'january': 1,
@@ -105,6 +106,8 @@ datetimeParser = {
             'november': 11,
             'december': 12
         },
+        'date_fmt': '%d/%m/%y',
+        'time_fmt': '%H:%M',
         'iso6392': 'eng'
     },
     'es_ES': {


### PR DESCRIPTION
Fixes:
~~~
2025-12-27 14:02:09.517 T:1239    error <general>: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                                    - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                                   Error Type: <class 'KeyError'>
                                                   Error Contents: 'date_fmt'
                                                   Traceback (most recent call last):
                                                     File "/storage/.kodi/addons/plugin.video.amazon-test/default.py", line 9, in <module>
                                                       EntryPoint(argv)
                                                     File "/storage/.kodi/addons/plugin.video.amazon-test/resources/lib/startup.py", line 93, in EntryPoint
                                                       _g.pv.Route(mode, args)
                                                     File "/storage/.kodi/addons/plugin.video.amazon-test/resources/lib/android_api.py", line 700, in Route
                                                       self.getPage(args.get('url'), args.get('opt', ''), int(args.get('page', '1')), export=int(args.get('export', '0')))
                                                     File "/storage/.kodi/addons/plugin.video.amazon-test/resources/lib/android_api.py", line 248, in getPage
                                                       il = self.getInfos(model)
                                                            ^^^^^^^^^^^^^^^^^^^^
                                                     File "/storage/.kodi/addons/plugin.video.amazon-test/resources/lib/android_api.py", line 582, in getInfos
                                                       formstr = f"[B]{{:{cur_lang['date_fmt']}, {cur_lang['time_fmt']}}}[/B]\n\n{{}}"
                                                                          ~~~~~~~~^^^^^^^^^^^^
                                                   KeyError: 'date_fmt'
                                                   -->End of Python script error report<--
~~~