### PR TITLE
Title: Fix two crashes browsing Watchlist seasons (KeyError + JSON corruption)Fix watchlist season keyerror

### DIFF
--- a/plugin.video.amazon-test/resources/lib/web_api.py
+++ b/plugin.video.amazon-test/resources/lib/web_api.py
@@ -1129,7 +1129,7 @@ class PrimeVideo(Singleton):
 
                 # Meta prep
                 if 'metadata' not in vd:
-                    vd['metadata'] = {'compactGTI': urn, 'artmeta': {}, 'videometa': {}}
+                    vd['metadata'] = {'compactGTI': urn if urn is not None else title_id, 'artmeta': {}, 'videometa': {}}
                     bUpdated = True
                 if 'artmeta' not in vd['metadata']:
                     vd['metadata']['artmeta'] = {}

--- a/plugin.video.amazon-test/resources/lib/web_api.py
+++ b/plugin.video.amazon-test/resources/lib/web_api.py
@@ -917,7 +917,7 @@ class PrimeVideo(Singleton):
                 bEpisodesOnly = oid == gti
                 siblings = [] if bEpisodesOnly else vd['siblings'][:]
                 siblings.append(gti)
-                siblings = sorted(siblings, key=(lambda k: self._videodata[k]['metadata']['videometa']['season']))
+                siblings = sorted(siblings, key=(lambda k: ((self._videodata.get(k) or {}).get('metadata') or {}).get('videometa', {}).get('season', 999)))
                 for gti in siblings:
                     # Add season if we're not inside a season already
                     if (not bEpisodesOnly) and (gti not in o):


### PR DESCRIPTION
Description: 

I'm no expert here, and so treat this work as a hopefully helpful...  I'm using a bit of LLM to help me with getting my head around python. 
Heres what Ive done... Moz

Rebased onto 1.2.2. Distinct from the compactGTI/TypeError fix in #829 (thanks for that one) — that fixed a read-site guard at line 980; these two are a still-open crash and its root cause, found while digging into the same general area.

Bug 1 — KeyError: 'metadata' browsing into a show with an unhydrated season
Season nodes are seeded into self._videodata with only {'ref', 'children', 'siblings'} when first discovered via a show's listing. They only gain metadata.videometa.season once their own page is individually parsed. The cache-hit sort in ParseSinglePage assumed every sibling already had this populated:
File ".../web_api.py", line 920, in ParseSinglePage
  siblings = sorted(siblings, key=(lambda k: self._videodata[k]['metadata']['videometa']['season']))
KeyError: 'metadata'
Fix: defensive .get() chaining with a sentinel default (999), so unhydrated seasons sort after fully-loaded ones instead of crashing. They self-correct once their own page is parsed.

Bug 2 — Cache corruption / silent data loss on season-selector pages
ParseSinglePage sets metadata.compactGTI = ExtractURN(url) for any newly-seen GTI. Pages reached via a season-selector ref (?ref_=atv_dp_season_select_sN) don't match the URN-extraction regex (no trailing slash before the query string), so urn is None for every node first seen this way — including the show itself and any siblings in the same response.
That None gets written into the cache as compactGTI. Once enough accumulate, json.dump(..., sort_keys=True) in _Flush crashes with TypeError: '<' not supported between instances of 'NoneType' and 'str'. The addon then detects its own cache file is corrupted and deletes it — from the user's side, browsing an affected season silently wipes the whole cache and leaves it empty next visit. This is the same compactGTI: None root cause behind #829's symptom, just hitting a different consumer (the write site / later serialization, rather than the membership check fixed there).
Fix: fall back to title_id (the page's own pageTitleId, always valid at this point) when urn is None, instead of storing None.

Testing: Reproduced and verified via direct log capture and targeted debug logging on LibreELEC / Raspberry Pi 4, Kodi Matrix. Confirmed clean cold-cache browsing (Watchlist → show → multiple seasons → episode playback) with both fixes applied, no crashes, no cache corruption.